### PR TITLE
Use retagged alpine image

### DIFF
--- a/helm/kubernetes-nginx-ingress-controller-chart/templates/controller-deployment.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/templates/controller-deployment.yaml
@@ -48,7 +48,7 @@ spec:
         - sh
         - -c
         - sysctl -w net.core.somaxconn=32768; sysctl -w net.ipv4.ip_local_port_range="1024 65535"
-        image: "{{ .Values.controller.initContainer.image.repository }}:{{ .Values.initContainer.controller.image.tag }}"
+        image: "{{ .Values.initContainer.image.repository }}:{{ .Values.initContainer.image.tag }}"
         imagePullPolicy: IfNotPresent
         name: sysctl
         securityContext:

--- a/helm/kubernetes-nginx-ingress-controller-chart/templates/controller-deployment.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/templates/controller-deployment.yaml
@@ -48,7 +48,7 @@ spec:
         - sh
         - -c
         - sysctl -w net.core.somaxconn=32768; sysctl -w net.ipv4.ip_local_port_range="1024 65535"
-        image: alpine:3.6
+        image: "{{ .Values.controller.initContainer.image.repository }}:{{ .Values.initContainer.controller.image.tag }}"
         imagePullPolicy: IfNotPresent
         name: sysctl
         securityContext:

--- a/helm/kubernetes-nginx-ingress-controller-chart/values.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/values.yaml
@@ -14,6 +14,11 @@ controller:
     repository: quay.io/giantswarm/nginx-ingress-controller
     tag: 0.11.0
 
+  initContainer:
+    image:
+      repository: quay.io/giantswarm/alpine
+      tag: 3.7
+
   service:
     nodePorts:
       http: 30010

--- a/helm/kubernetes-nginx-ingress-controller-chart/values.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/values.yaml
@@ -14,11 +14,6 @@ controller:
     repository: quay.io/giantswarm/nginx-ingress-controller
     tag: 0.11.0
 
-  initContainer:
-    image:
-      repository: quay.io/giantswarm/alpine
-      tag: 3.7
-
   service:
     nodePorts:
       http: 30010
@@ -49,6 +44,11 @@ defaultBackend:
     requests:
       cpu: 10m
       memory: 20Mi
+
+initContainer:
+  image:
+    repository: quay.io/giantswarm/alpine
+    tag: 3.7
 
 test:
   image:


### PR DESCRIPTION
Towards: giantswarm/adidas#320

Preparing for China we need to use retagged images everywhere. Using latest `alpine:3.7` as we already do in `k8scc`.