### PR TITLE
Disable server tokens

### DIFF
--- a/helm/kubernetes-nginx-ingress-controller-chart/Chart.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: v0.11.0
 description: A Helm chart for the nginx ingress-controller
 name: kubernetes-nginx-ingress-controller-chart
-version: 0.1.5
+version: 0.1.6

--- a/helm/kubernetes-nginx-ingress-controller-chart/templates/configmap.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/templates/configmap.yaml
@@ -10,3 +10,4 @@ data:
   # Increase hash table size to allow more server names for stability reasons
   server-name-hash-bucket-size: "1024"
   server-name-hash-max-size: "1024"
+  server-tokens: "false"


### PR DESCRIPTION
Keeps chart in sync with k8scloudconfig change. Disables the server tokens for security to avoid leaking information.

See https://github.com/giantswarm/k8scloudconfig/pull/374