### PR TITLE
Update Ingress Controller to 0.12.0

### DIFF
--- a/helm/kubernetes-nginx-ingress-controller-chart/Chart.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: v0.11.0
+appVersion: v0.12.0
 description: A Helm chart for the nginx ingress-controller
 name: kubernetes-nginx-ingress-controller-chart
-version: 0.1.6
+version: 0.1.8

--- a/helm/kubernetes-nginx-ingress-controller-chart/values.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/values.yaml
@@ -12,7 +12,7 @@ controller:
 
   image:
     repository: quay.io/giantswarm/nginx-ingress-controller
-    tag: 0.11.0
+    tag: 0.12.0
 
   service:
     nodePorts:


### PR DESCRIPTION
Updates Ingress Controler to 0.12.0 to match current k8scloudconfig.

Going to update to 0.15.0 as a later step. After I've tested IC and to test updating charts.