### PR TITLE
Add $.Release.Time to deployment descriptor

### DIFF
--- a/helm/kubernetes-nginx-ingress-controller-chart/templates/controller-deployment.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/templates/controller-deployment.yaml
@@ -25,7 +25,6 @@ spec:
         giantswarm.io/service-type: "managed"
         k8s-app: {{ .Values.controller.name }}
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         releasetime: {{ $.Release.Time }}
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:

--- a/helm/kubernetes-nginx-ingress-controller-chart/templates/controller-deployment.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/templates/controller-deployment.yaml
@@ -26,6 +26,7 @@ spec:
         k8s-app: {{ .Values.controller.name }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        releasetime: {{ $.Release.Time }}
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       affinity:

--- a/helm/kubernetes-nginx-ingress-controller-chart/templates/default-backend-deployment.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/templates/default-backend-deployment.yaml
@@ -13,6 +13,9 @@ spec:
       k8s-app: {{ .Values.defaultBackend.name }}
   template:
     metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        releasetime: {{ $.Release.Time }}
       labels:
         giantswarm.io/service-type: "managed"
         k8s-app: {{ .Values.defaultBackend.name }}

--- a/helm/kubernetes-nginx-ingress-controller-chart/templates/default-backend-deployment.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/templates/default-backend-deployment.yaml
@@ -14,7 +14,6 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         releasetime: {{ $.Release.Time }}
       labels:
         giantswarm.io/service-type: "managed"


### PR DESCRIPTION
In order to make Helm always deploy PODs on deploy event, add release
time to deployment annotation. This changes on every deploy event which
changes deployment descriptor and therefore triggers Helm.

Towards https://github.com/giantswarm/giantswarm/issues/3395