### PR TITLE
Disable SSL passhtru. Align with k8scc

### DIFF
--- a/helm/kubernetes-nginx-ingress-controller-chart/Chart.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: v0.12.0
 description: A Helm chart for the nginx ingress-controller
 name: kubernetes-nginx-ingress-controller-chart
-version: 0.1.9
+version: 0.1.10

--- a/helm/kubernetes-nginx-ingress-controller-chart/templates/controller-deployment.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/templates/controller-deployment.yaml
@@ -60,7 +60,6 @@ spec:
         - /nginx-ingress-controller
         - --default-backend-service=$(POD_NAMESPACE)/{{ .Values.defaultBackend.name }}
         - --configmap=$(POD_NAMESPACE)/ingress-nginx
-        - --enable-ssl-passthrough
         - --annotations-prefix=nginx.ingress.kubernetes.io
         env:
         - name: POD_NAME


### PR DESCRIPTION
We have sslpassthru disabled in k8scc for a while. So disable it here too.

Source: https://github.com/giantswarm/k8scloudconfig/pull/353