### PR TITLE
Use static worker count for nginx

### DIFF
--- a/helm/kubernetes-nginx-ingress-controller-chart/Chart.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: v0.12.0
 description: A Helm chart for the nginx ingress-controller
 name: kubernetes-nginx-ingress-controller-chart
-version: 0.1.11
+version: 0.1.12

--- a/helm/kubernetes-nginx-ingress-controller-chart/templates/configmap.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/templates/configmap.yaml
@@ -12,3 +12,4 @@ data:
   server-name-hash-bucket-size: "1024"
   server-name-hash-max-size: "1024"
   server-tokens: "false"
+  worker-processes: "4"


### PR DESCRIPTION
By default controller starts worker number equal to number of cores. Every worker consumes 45MB memory in stand-by, this causes OOM kills (for default limit 700MB) if core number >=16 (Big VMs).

Fixes: https://github.com/giantswarm/giantswarm/issues/3536