### PR TITLE
Disable HSTS

### DIFF
--- a/helm/kubernetes-nginx-ingress-controller-chart/Chart.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: v0.12.0
 description: A Helm chart for the nginx ingress-controller
 name: kubernetes-nginx-ingress-controller-chart
-version: 0.2.0
+version: 0.2.1

--- a/helm/kubernetes-nginx-ingress-controller-chart/templates/configmap.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/templates/configmap.yaml
@@ -13,3 +13,6 @@ data:
   server-name-hash-max-size: "1024"
   server-tokens: "false"
   worker-processes: "4"
+  # Disables setting a 'Strict-Transport-Security' header, which can be harmful.
+  # See https://github.com/kubernetes/ingress-nginx/issues/549#issuecomment-291894246
+  hsts: "false"


### PR DESCRIPTION
Related to https://github.com/giantswarm/giantswarm/issues/3841

This change turns off strict HSTS headers which are normally set by NGINX ingress controller if HTTPS termination is performed in the IC.

https://github.com/kubernetes/ingress-nginx/issues/549#issuecomment-291894246 explains in more detail why that header can be harmful and should be activated consciously, as opposed to coming as an unexpected side effect.

Setting `hsts: "false"` in the configmap enables customers to use configuration snippet annotations like shown below in their ingress manifest in order to enable a custom HSTS header.

```yaml
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  name: my-ingress
  annotations:
    nginx.ingress.kubernetes.io/configuration-snippet: |
      more_set_headers "Strict-Transport-Security: max-age=60; includeSubDomains;";
spec:
  ...
```