### PR TITLE
Migration setup

### DIFF
--- a/helm/kubernetes-nginx-ingress-controller-chart/Chart.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: v0.12.0
 description: A Helm chart for the nginx ingress-controller
 name: kubernetes-nginx-ingress-controller-chart
-version: 0.1.12
+version: 0.2.0

--- a/helm/kubernetes-nginx-ingress-controller-chart/templates/configmap.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/templates/configmap.yaml
@@ -1,7 +1,7 @@
 kind: ConfigMap
 apiVersion: v1
 metadata:
-  name: ingress-nginx
+  name: {{ .Values.controller.configmap.name }}
   namespace: {{ .Values.namespace }}
   labels:
     giantswarm.io/service-type: "managed"

--- a/helm/kubernetes-nginx-ingress-controller-chart/templates/controller-deployment.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/templates/controller-deployment.yaml
@@ -59,7 +59,7 @@ spec:
         args:
         - /nginx-ingress-controller
         - --default-backend-service=$(POD_NAMESPACE)/{{ .Values.defaultBackend.name }}
-        - --configmap=$(POD_NAMESPACE)/ingress-nginx
+        - --configmap=$(POD_NAMESPACE)/{{ .Values.controller.configmap.name }}
         - --annotations-prefix=nginx.ingress.kubernetes.io
         env:
         - name: POD_NAME

--- a/helm/kubernetes-nginx-ingress-controller-chart/values.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/values.yaml
@@ -10,6 +10,9 @@ controller:
 
   replicas: 3
 
+  configmap:
+    name: ingress-nginx
+
   image:
     registry: quay.io
     repository: giantswarm/nginx-ingress-controller


### PR DESCRIPTION
This is prep for the Ingress Controller rollout on AWS and KVM.

Currently the IC configmap is hardcoded to `ingress-nginx`. This makes it configurable so we can create a second set of resources before deleting the current resources.

Also bumps the version to 0.2.0 so we use a new release channel. This is to give more control over the rollout.
