### PR TITLE
Add app labels and replace configmap

### DIFF
--- a/helm/kubernetes-nginx-ingress-controller-chart/Chart.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: v0.12.0
 description: A Helm chart for the nginx ingress-controller
 name: kubernetes-nginx-ingress-controller-chart
-version: 0.2.1
+version: 0.2.2

--- a/helm/kubernetes-nginx-ingress-controller-chart/charts/migration/templates/configmap.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/charts/migration/templates/configmap.yaml
@@ -70,6 +70,17 @@ data:
             }
         },
         {
+            "kind": "ConfigMap",
+            "name": "ingress-nginx",
+            "namespace": "kube-system",
+            "matchLabels": {
+                "k8s-addon": "k8s-addon: ingress-nginx.addons.k8s.io"
+            },
+            "excludeLabels": {
+                "giantswarm.io/service-type": "managed"
+            }
+        },
+        {
             "kind": "ServiceAccount",
             "name": "nginx-ingress-controller",
             "namespace": "kube-system",

--- a/helm/kubernetes-nginx-ingress-controller-chart/charts/migration/templates/configmap.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/charts/migration/templates/configmap.yaml
@@ -74,7 +74,7 @@ data:
             "name": "ingress-nginx",
             "namespace": "kube-system",
             "matchLabels": {
-                "k8s-addon": "k8s-addon: ingress-nginx.addons.k8s.io"
+                "k8s-addon": "ingress-nginx.addons.k8s.io"
             },
             "excludeLabels": {
                 "giantswarm.io/service-type": "managed"

--- a/helm/kubernetes-nginx-ingress-controller-chart/charts/migration/templates/rbac.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/charts/migration/templates/rbac.yaml
@@ -30,6 +30,7 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps
   - services
   - serviceaccounts
   verbs:

--- a/helm/kubernetes-nginx-ingress-controller-chart/templates/configmap.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/templates/configmap.yaml
@@ -4,9 +4,8 @@ metadata:
   name: {{ .Values.controller.configmap.name }}
   namespace: {{ .Values.namespace }}
   labels:
-    app: {{ .Values.controller.name }}
     giantswarm.io/service-type: "managed"
-    k8s-app: {{ .Values.controller.k8sAppLabel }}
+    k8s-addon: ingress-nginx.addons.k8s.io
 data:
   enable-vts-status: "true"
   # Increase hash table size to allow more server names for stability reasons

--- a/helm/kubernetes-nginx-ingress-controller-chart/templates/configmap.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/templates/configmap.yaml
@@ -4,8 +4,9 @@ metadata:
   name: {{ .Values.controller.configmap.name }}
   namespace: {{ .Values.namespace }}
   labels:
+    app: {{ .Values.controller.name }}
     giantswarm.io/service-type: "managed"
-    k8s-app: {{ .Values.controller.name }}
+    k8s-app: {{ .Values.controller.k8sAppLabel }}
 data:
   enable-vts-status: "true"
   # Increase hash table size to allow more server names for stability reasons

--- a/helm/kubernetes-nginx-ingress-controller-chart/templates/controller-deployment.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/templates/controller-deployment.yaml
@@ -4,8 +4,9 @@ metadata:
   name: {{ .Values.controller.name }}
   namespace: {{ .Values.namespace }}
   labels:
+    app: {{ .Values.controller.name }}
     giantswarm.io/service-type: "managed"
-    k8s-app: {{ .Values.controller.name }}
+    k8s-app: {{ .Values.controller.k8sAppLabel }}
   annotations:
     prometheus.io/port: '{{ .Values.controller.metricsPort }}'
     prometheus.io/scrape: 'true'
@@ -13,7 +14,8 @@ spec:
   replicas: {{ .Values.controller.replicas }}
   selector:
     matchLabels:
-      k8s-app: {{ .Values.controller.name }}
+      app: {{ .Values.controller.name }}
+      k8s-app: {{ .Values.controller.k8sAppLabel }}
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -22,8 +24,9 @@ spec:
   template:
     metadata:
       labels:
+        app: {{ .Values.controller.name }}
         giantswarm.io/service-type: "managed"
-        k8s-app: {{ .Values.controller.name }}
+        k8s-app: {{ .Values.controller.k8sAppLabel }}
       annotations:
         releasetime: {{ $.Release.Time }}
         scheduler.alpha.kubernetes.io/critical-pod: ''
@@ -35,7 +38,7 @@ spec:
             podAffinityTerm:
               labelSelector:
                 matchExpressions:
-                - key: k8s-app
+                - key: app
                   operator: In
                   values:
                   - {{ .Values.controller.name }}

--- a/helm/kubernetes-nginx-ingress-controller-chart/templates/controller-deployment.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/templates/controller-deployment.yaml
@@ -14,7 +14,6 @@ spec:
   replicas: {{ .Values.controller.replicas }}
   selector:
     matchLabels:
-      app: {{ .Values.controller.name }}
       k8s-app: {{ .Values.controller.k8sAppLabel }}
   strategy:
     type: RollingUpdate

--- a/helm/kubernetes-nginx-ingress-controller-chart/templates/controller-service.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/templates/controller-service.yaml
@@ -12,6 +12,20 @@ metadata:
     giantswarm.io/service-type: "managed"
     k8s-app: {{ .Values.controller.k8sAppLabel }}
 spec:
+  {{- if eq .Values.controller.service.type "ClusterIP" }}
+  type: ClusterIP
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  - name: https
+    port: 443
+    protocol: TCP
+    targetPort: 443
+  selector:
+    k8s-app: {{ .Values.controller.k8sAppLabel }}
+  {{- else}}
   type: NodePort
   ports:
   - name: http
@@ -26,3 +40,4 @@ spec:
     targetPort: 443
   selector:
     k8s-app: {{ .Values.controller.name }}
+  {{- end}}

--- a/helm/kubernetes-nginx-ingress-controller-chart/templates/controller-service.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/templates/controller-service.yaml
@@ -12,20 +12,6 @@ metadata:
     giantswarm.io/service-type: "managed"
     k8s-app: {{ .Values.controller.k8sAppLabel }}
 spec:
-  {{- if eq .Values.controller.service.type "ClusterIP" }}
-  type: ClusterIP
-  ports:
-  - name: http
-    port: 80
-    protocol: TCP
-    targetPort: 80
-  - name: https
-    port: 443
-    protocol: TCP
-    targetPort: 443
-  selector:
-    k8s-app: {{ .Values.controller.k8sAppLabel }}
-  {{- else}}
   type: NodePort
   ports:
   - name: http
@@ -39,5 +25,4 @@ spec:
     protocol: TCP
     targetPort: 443
   selector:
-    k8s-app: {{ .Values.controller.name }}
-  {{- end}}
+    k8s-app: {{ .Values.controller.k8sAppLabel }}

--- a/helm/kubernetes-nginx-ingress-controller-chart/templates/controller-service.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/templates/controller-service.yaml
@@ -8,8 +8,9 @@ metadata:
   name: {{ .Values.controller.name }}
   namespace: {{ .Values.namespace }}
   labels:
+    app: {{ .Values.controller.name }}
     giantswarm.io/service-type: "managed"
-    k8s-app: {{ .Values.controller.name }}
+    k8s-app: {{ .Values.controller.k8sAppLabel }}
 spec:
   type: NodePort
   ports:

--- a/helm/kubernetes-nginx-ingress-controller-chart/values.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/values.yaml
@@ -23,7 +23,6 @@ controller:
     nodePorts:
       http: 30010
       https: 30011
-    type: NodePort
 
   resources:
     limits:

--- a/helm/kubernetes-nginx-ingress-controller-chart/values.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/values.yaml
@@ -6,6 +6,7 @@ namespace: kube-system
 
 controller:
   name: nginx-ingress-controller
+  k8sAppLabel: nginx-ingress-controller
   metricsPort: 10254
 
   replicas: 3

--- a/helm/kubernetes-nginx-ingress-controller-chart/values.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/values.yaml
@@ -23,6 +23,7 @@ controller:
     nodePorts:
       http: 30010
       https: 30011
+    type: NodePort
 
   resources:
     limits:

--- a/integration/test/basic/basic_test.go
+++ b/integration/test/basic/basic_test.go
@@ -41,7 +41,6 @@ func TestHelm(t *testing.T) {
 		"k8s-app":                    controllerName,
 	}
 	controllerMatchLabels := map[string]string{
-		"app":     controllerName,
 		"k8s-app": controllerName,
 	}
 	err = checkDeployment(controllerName, 3, controllerLabels, controllerMatchLabels)

--- a/integration/test/migration/fixtures/resources-chart/templates/resources.yaml
+++ b/integration/test/migration/fixtures/resources-chart/templates/resources.yaml
@@ -37,6 +37,17 @@ metadata:
     k8s-app: nginx-ingress-controller
     kind: legacy
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ingress-nginx
+  namespace: kube-system
+  labels:
+    k8s-addon: ingress-nginx.addons.k8s.io
+    kind: legacy
+data:
+  enable-vts-status: "true"
+---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:

--- a/integration/test/migration/migration_test.go
+++ b/integration/test/migration/migration_test.go
@@ -82,7 +82,7 @@ func checkResourcesPresent(labelSelector string) error {
 		LabelSelector: fmt.Sprintf("k8s-app=default-http-backend,%s", labelSelector),
 	}
 	configMapListOptions := metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("k8s-addon=ngress-nginx.addons.k8s.io,%s", labelSelector),
+		LabelSelector: fmt.Sprintf("k8s-addon=ingress-nginx.addons.k8s.io,%s", labelSelector),
 	}
 
 	cm, err := c.Core().ConfigMaps(resourceNamespace).List(configMapListOptions)

--- a/integration/test/migration/migration_test.go
+++ b/integration/test/migration/migration_test.go
@@ -81,7 +81,7 @@ func checkResourcesPresent(labelSelector string) error {
 	backendListOptions := metav1.ListOptions{
 		LabelSelector: fmt.Sprintf("k8s-app=default-http-backend,%s", labelSelector),
 	}
-	configMapOptions := metav1.ListOptions{
+	configMapListOptions := metav1.ListOptions{
 		LabelSelector: fmt.Sprintf("k8s-addon=ngress-nginx.addons.k8s.io,%s", labelSelector),
 	}
 
@@ -90,7 +90,7 @@ func checkResourcesPresent(labelSelector string) error {
 		return microerror.Mask(err)
 	}
 	if len(cm.Items) != 1 {
-		return microerror.Newf("unexpected number of configmaps, want 1, got %d", len(d.Items))
+		return microerror.Newf("unexpected number of configmaps, want 1, got %d", len(cm.Items))
 	}
 
 	d, err := c.Extensions().Deployments(resourceNamespace).List(controllerListOptions)
@@ -176,7 +176,7 @@ func checkResourcesNotPresent(labelSelector string) error {
 	backendListOptions := metav1.ListOptions{
 		LabelSelector: fmt.Sprintf("k8s-app=default-http-backend,%s", labelSelector),
 	}
-	configMapOptions := metav1.ListOptions{
+	configMapListOptions := metav1.ListOptions{
 		LabelSelector: fmt.Sprintf("k8s-addon=ngress-nginx.addons.k8s.io,%s", labelSelector),
 	}
 

--- a/integration/test/migration/migration_test.go
+++ b/integration/test/migration/migration_test.go
@@ -81,6 +81,17 @@ func checkResourcesPresent(labelSelector string) error {
 	backendListOptions := metav1.ListOptions{
 		LabelSelector: fmt.Sprintf("k8s-app=default-http-backend,%s", labelSelector),
 	}
+	configMapOptions := metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("k8s-addon=ngress-nginx.addons.k8s.io,%s", labelSelector),
+	}
+
+	cm, err := c.Core().ConfigMaps(resourceNamespace).List(configMapListOptions)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	if len(cm.Items) != 1 {
+		return microerror.Newf("unexpected number of configmaps, want 1, got %d", len(d.Items))
+	}
 
 	d, err := c.Extensions().Deployments(resourceNamespace).List(controllerListOptions)
 	if err != nil {
@@ -164,6 +175,17 @@ func checkResourcesNotPresent(labelSelector string) error {
 	}
 	backendListOptions := metav1.ListOptions{
 		LabelSelector: fmt.Sprintf("k8s-app=default-http-backend,%s", labelSelector),
+	}
+	configMapOptions := metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("k8s-addon=ngress-nginx.addons.k8s.io,%s", labelSelector),
+	}
+
+	cm, err := c.Core().ConfigMaps(resourceNamespace).List(configMapListOptions)
+	if err == nil && len(cm.Items) > 0 {
+		return microerror.New("expected error querying for configmaps didn't happen")
+	}
+	if !apierrors.IsNotFound(err) {
+		return microerror.Mask(err)
 	}
 
 	d, err := c.Extensions().Deployments(resourceNamespace).List(controllerListOptions)


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/3710

This PR is more preparation for the migration. 

- Adds the IC configmap to the resources deleted by the migration job. Otherwise installing the chart will fail.
- Adds app labels to existing k8s-app labels for the controller resources. This is so a 2nd set of resources can be started before deleting the existing pods.