### PR TITLE
Remove configuration table from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,4 +22,4 @@ Provide a custom `values.yaml`:
 $ helm install kubernetes-nginx-ingress-controller-chart -f values.yaml
 ```
 
-Deployment to Guest Clusters will be handled by [chart-operator](https://github.com/giantswarm/chart-operator)
+Deployment to Guest Clusters is handled by [chart-operator](https://github.com/giantswarm/chart-operator).

--- a/README.md
+++ b/README.md
@@ -23,23 +23,3 @@ $ helm install kubernetes-nginx-ingress-controller-chart -f values.yaml
 ```
 
 Deployment to Guest Clusters will be handled by [chart-operator](https://github.com/giantswarm/chart-operator)
-
-## Configuration
-
-| Parameter                            | Description                                             | Default                                       |
-|--------------------------------------|---------------------------------------------------------|-----------------------------------------------|
-| `controller.name`                    | The name of the ingress controller                      | `nginx-ingress-controller`                    |
-| `controller.image.repository`        | The controller container image repository               | `quay.io/giantswarm/nginx-ingress-controller` |
-| `controller.image.tag`               | The controller container image tag                      | `0.11.0`                                      |
-| `controller.replicaCount`            | The desired number of controller pods                   | `3`                                           |
-| `controller.resources`               | The controller pod resource requests & limits           | `cpu:500m memory:350Mi`                       |
-| `controller.metricsPort`             | Sets the metricsport used for metrics and health checks | `10254`                                       |
-| `controller.service.nodePorts.http`  | Sets the nodePort that maps to the Ingress' port 80     | `30010`                                       |
-| `controller.service.nodePorts.https` | Sets the nodePort that maps to the Ingress' port 443    | `30011`                                       |
-| `defaultBackend.name`                | The name of the default backend component               | `default-http-backend`                        |
-| `defaultBackend.image.repository`    | The default backend container image repository          | `quay.io/giantswarm/defaultbackend`           |
-| `defaultBackend.image.tag`           | The default backend container image tag                 | `1.2`                                         |
-| `defaultBackend.replicaCount`        | The desired number of default backend pods              | `2`                                           |
-| `defaultBackend.resources`           | The default backend pod resource requests & limits      | `cpu:10m memory:20Mi`                         |
-| `test.image.repository`              | The test image repository to pull from                  | `quay.io/giantswarm/alpine-testing`           |
-| `test.image.tag`                     | The test image tag to pull                              | `0.1.0`                                       |

--- a/helm/kubernetes-nginx-ingress-controller-chart/values.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/values.yaml
@@ -18,7 +18,7 @@ controller:
     repository: giantswarm/nginx-ingress-controller
     tag: 0.12.0
 
-  # Sets the NodePorts that maps to the Ingress' ports 80 (http) and 443 (https)
+  # Sets the NodePorts that maps to the Ingress' ports 80 (http) and 443 (https).
   service:
     nodePorts:
       http: 30010

--- a/helm/kubernetes-nginx-ingress-controller-chart/values.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/values.yaml
@@ -18,6 +18,7 @@ controller:
     repository: giantswarm/nginx-ingress-controller
     tag: 0.12.0
 
+  # Sets the NodePorts that maps to the Ingress' ports 80 (http) and 443 (https)
   service:
     nodePorts:
       http: 30010


### PR DESCRIPTION
As discussed here https://github.com/giantswarm/kubernetes-coredns/pull/2#discussion_r206114148.

The table gets outdated and is basically a duplicate what is already in `values.yaml`. Specifics can be added as comments there.