### PR TITLE
Add enabled flag for Controller service and app labels for Default Backend

### DIFF
--- a/helm/kubernetes-nginx-ingress-controller-chart/Chart.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: v0.12.0
 description: A Helm chart for the nginx ingress-controller
 name: kubernetes-nginx-ingress-controller-chart
-version: 0.2.2
+version: 0.2.3

--- a/helm/kubernetes-nginx-ingress-controller-chart/templates/controller-service.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/templates/controller-service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.controller.service.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -26,3 +27,4 @@ spec:
     targetPort: 443
   selector:
     k8s-app: {{ .Values.controller.k8sAppLabel }}
+{{-  end }}

--- a/helm/kubernetes-nginx-ingress-controller-chart/templates/default-backend-deployment.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/templates/default-backend-deployment.yaml
@@ -4,20 +4,22 @@ metadata:
   name: {{ .Values.defaultBackend.name }}
   namespace: {{ .Values.namespace }}
   labels:
+    app: {{ .Values.defaultBackend.name }}
     giantswarm.io/service-type: "managed"
-    k8s-app: {{ .Values.defaultBackend.name }}
+    k8s-app: {{ .Values.defaultBackend.k8sAppLabel }}
 spec:
   replicas: {{ .Values.defaultBackend.replicas }}
   selector:
     matchLabels:
-      k8s-app: {{ .Values.defaultBackend.name }}
+      k8s-app: {{ .Values.defaultBackend.k8sAppLabel }}
   template:
     metadata:
       annotations:
         releasetime: {{ $.Release.Time }}
       labels:
+        app: {{ .Values.defaultBackend.name }}
         giantswarm.io/service-type: "managed"
-        k8s-app: {{ .Values.defaultBackend.name }}
+        k8s-app: {{ .Values.defaultBackend.k8sAppLabel }}
     spec:
       containers:
       - name: {{ .Values.defaultBackend.name }}

--- a/helm/kubernetes-nginx-ingress-controller-chart/templates/default-backend-service.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/templates/default-backend-service.yaml
@@ -4,8 +4,9 @@ metadata:
   name: {{ .Values.defaultBackend.name }}
   namespace: {{ .Values.namespace }}
   labels:
+    app: {{ .Values.defaultBackend.name }}
     giantswarm.io/service-type: "managed"
-    k8s-app: {{ .Values.defaultBackend.name }}
+    k8s-app: {{ .Values.defaultBackend.k8sAppLabel }}
 spec:
   type: NodePort
   ports:

--- a/helm/kubernetes-nginx-ingress-controller-chart/templates/rbac.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/templates/rbac.yaml
@@ -3,8 +3,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Values.controller.name }}
   labels:
+    app: {{ .Values.controller.name }}
     giantswarm.io/service-type: "managed"
-    k8s-app: {{ .Values.controller.name }}
+    k8s-app: {{ .Values.controller.k8sAppLabel }}
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.controller.name }}
@@ -20,8 +21,9 @@ metadata:
   name: {{ .Values.controller.name }}
   namespace: {{ .Values.namespace }}
   labels:
+    app: {{ .Values.controller.name }}
     giantswarm.io/service-type: "managed"
-    k8s-app: {{ .Values.controller.name }}
+    k8s-app: {{ .Values.controller.k8sAppLabel }}
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.controller.name }}
@@ -37,8 +39,9 @@ metadata:
   name: {{ .Values.controller.name }}
   namespace: {{ .Values.namespace }}
   labels:
+    app: {{ .Values.controller.name }}
     giantswarm.io/service-type: "managed"
-    k8s-app: {{ .Values.controller.name }}
+    k8s-app: {{ .Values.controller.k8sAppLabel }}
 rules:
 - apiGroups:
   - ""
@@ -93,8 +96,9 @@ metadata:
   name: nginx-ingress-role
   namespace: {{ .Values.namespace }}
   labels:
+    app: {{ .Values.controller.name }}
     giantswarm.io/service-type: "managed"
-    k8s-app: {{ .Values.controller.name }}
+    k8s-app: {{ .Values.controller.k8sAppLabel }}
 rules:
 - apiGroups:
   - ""

--- a/helm/kubernetes-nginx-ingress-controller-chart/values.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/values.yaml
@@ -36,6 +36,7 @@ controller:
 
 defaultBackend:
   name: default-http-backend
+  k8sAppLabel: default-http-backend
   port: 8080
 
   replicas: 2

--- a/helm/kubernetes-nginx-ingress-controller-chart/values.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/values.yaml
@@ -21,6 +21,7 @@ controller:
 
   # Sets the NodePorts that maps to the Ingress' ports 80 (http) and 443 (https).
   service:
+    enabled: true
     nodePorts:
       http: 30010
       https: 30011

--- a/integration/test/basic/basic_test.go
+++ b/integration/test/basic/basic_test.go
@@ -50,6 +50,7 @@ func TestHelm(t *testing.T) {
 
 	backendName := "default-http-backend"
 	backendLabels := map[string]string{
+		"app": backendName,
 		"giantswarm.io/service-type": "managed",
 		"k8s-app":                    backendName,
 	}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/3710

Adds an enabled flag for the Controller service. This is so it can be enabled on Azure and disabled on AWS and KVM.

Also adds app labels to the Default Backend resources. These are used by the e2e tests and allow a 2nd set of resources to be created alongside the resources to be migrated.