### PR TITLE
Migration changes

### DIFF
--- a/helm/kubernetes-nginx-ingress-controller-chart/Chart.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: v0.12.0
 description: A Helm chart for the nginx ingress-controller
 name: kubernetes-nginx-ingress-controller-chart
-version: 0.2.3
+version: 0.2.4

--- a/helm/kubernetes-nginx-ingress-controller-chart/charts/migration/templates/configmap.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/charts/migration/templates/configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.global.migration.job.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -136,3 +137,4 @@ data:
             }
         }
     ]
+{{- end }}

--- a/helm/kubernetes-nginx-ingress-controller-chart/charts/migration/templates/configmap.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/charts/migration/templates/configmap.yaml
@@ -28,17 +28,6 @@ data:
     [
         {
             "kind": "Service",
-            "name": "nginx-ingress-controller",
-            "namespace": "kube-system",
-            "matchLabels": {
-                "k8s-app": "nginx-ingress-controller"
-            },
-            "excludeLabels": {
-                "giantswarm.io/service-type": "managed"
-            }
-        },
-        {
-            "kind": "Service",
             "name": "default-http-backend",
             "namespace": "kube-system",
             "matchLabels": {

--- a/helm/kubernetes-nginx-ingress-controller-chart/charts/migration/templates/job.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/charts/migration/templates/job.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.global.migration.job.enabled }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -36,3 +37,4 @@ spec:
 {{ toYaml .Values.resources | indent 10 }}
       restartPolicy: Never
   backoffLimit: 4
+{{- end }}

--- a/helm/kubernetes-nginx-ingress-controller-chart/charts/migration/templates/rbac.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/charts/migration/templates/rbac.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.global.migration.job.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
@@ -56,3 +57,4 @@ roleRef:
   kind: ClusterRole
   name: {{ .Values.name }}
   apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/helm/kubernetes-nginx-ingress-controller-chart/charts/migration/templates/service-account.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/charts/migration/templates/service-account.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.global.migration.job.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -10,3 +11,4 @@ metadata:
   labels:
     app: {{ .Values.name }}
     giantswarm.io/service-type: "managed"
+{{- end }}

--- a/helm/kubernetes-nginx-ingress-controller-chart/values.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/values.yaml
@@ -54,6 +54,11 @@ defaultBackend:
       cpu: 10m
       memory: 20Mi
 
+global:
+  migration:
+    job:
+      enabled: false
+
 initContainer:
   image:
     registry: quay.io

--- a/integration/templates/ingress_controller_basic_values.go
+++ b/integration/templates/ingress_controller_basic_values.go
@@ -2,11 +2,12 @@
 
 package templates
 
-// NginxIngressControllerValues values required by kubernetes-nginx-ingress-controller-chart.
-const NginxIngressControllerValues = `namespace: kube-system
+// NginxIngressControllerBasicValues values required by kubernetes-nginx-ingress-controller-chart.
+const NginxIngressControllerBasicValues = `namespace: kube-system
 
 controller:
   name: nginx-ingress-controller
+  k8sAppLabel: nginx-ingress-controller
   metricsPort: 10254
 
   replicas: 3
@@ -20,6 +21,7 @@ controller:
     tag: 0.12.0
 
   service:
+    enabled: true
     nodePorts:
       http: 30010
       https: 30011
@@ -34,6 +36,7 @@ controller:
 
 defaultBackend:
   name: default-http-backend
+  k8sAppLabel: default-http-backend
   port: 8080
 
   replicas: 2
@@ -50,6 +53,11 @@ defaultBackend:
     requests:
       cpu: 10m
       memory: 20Mi
+
+global:
+  migration:
+    job:
+      enabled: false
 
 initContainer:
   image:

--- a/integration/templates/ingress_controller_migration_values.go
+++ b/integration/templates/ingress_controller_migration_values.go
@@ -1,0 +1,73 @@
+// +build k8srequired
+
+package templates
+
+// NginxIngressControllerMigrationValues values required by kubernetes-nginx-ingress-controller-chart.
+const NginxIngressControllerMigrationValues = `namespace: kube-system
+
+controller:
+  name: nginx-ingress-controller
+  k8sAppLabel: nginx-ingress-controller
+  metricsPort: 10254
+
+  replicas: 3
+
+  configmap:
+    name: ingress-nginx
+
+  image:
+    registry: quay.io
+    repository: giantswarm/nginx-ingress-controller
+    tag: 0.12.0
+
+  service:
+    enabled: false
+    nodePorts:
+      http: 30010
+      https: 30011
+
+  resources:
+    limits:
+      cpu: 500m
+      memory: 350Mi
+    requests:
+      cpu: 500m
+      memory: 350Mi
+
+defaultBackend:
+  name: default-http-backend
+  k8sAppLabel: default-http-backend
+  port: 8080
+
+  replicas: 2
+
+  image:
+    registry: quay.io
+    repository: giantswarm/defaultbackend
+    tag: 1.2
+
+  resources:
+    limits:
+      cpu: 10m
+      memory: 20Mi
+    requests:
+      cpu: 10m
+      memory: 20Mi
+
+global:
+  migration:
+    job:
+      enabled: true
+
+initContainer:
+  image:
+    registry: quay.io
+    repository: giantswarm/alpine
+    tag: 3.7
+
+test:
+  image:
+    registry: quay.io
+    repository: giantswarm/alpine-testing
+    tag: 0.1.0
+`

--- a/integration/test/basic/basic_test.go
+++ b/integration/test/basic/basic_test.go
@@ -23,7 +23,7 @@ func TestHelm(t *testing.T) {
 	channel := fmt.Sprintf("%s-%s", env.CircleSHA(), testName)
 	releaseName := "kubernetes-nginx-ingress-controller"
 
-	err := r.InstallResource(releaseName, templates.NginxIngressControllerValues, channel)
+	err := r.InstallResource(releaseName, templates.NginxIngressControllerBasicValues, channel)
 	if err != nil {
 		t.Fatalf("could not install %q %v", releaseName, err)
 	}

--- a/integration/test/migration/migration_test.go
+++ b/integration/test/migration/migration_test.go
@@ -35,6 +35,11 @@ func TestMigration(t *testing.T) {
 	}
 	defer framework.HelmCmd("delete resources --purge")
 
+	// Check controller service is present.
+	err = checkControllerServicePresent()
+	if err != nil {
+		t.Fatalf("controller service present: %v", err)
+	}
 	// Check legacy resources are present.
 	err = checkResourcesPresent("kind=legacy")
 	if err != nil {
@@ -71,6 +76,28 @@ func TestMigration(t *testing.T) {
 	if err != nil {
 		t.Fatalf("managed resources not present: %v", err)
 	}
+	// Check controller service is still present.
+	err = checkControllerServicePresent()
+	if err != nil {
+		t.Fatalf("controller service present: %v", err)
+	}
+}
+
+func checkControllerServicePresent() error {
+	c := h.K8sClient()
+
+	controllerListOptions := metav1.ListOptions{
+		LabelSelector: "k8s-app=nginx-ingress-controller,kind=legacy",
+	}
+	s, err := c.Core().Services(resourceNamespace).List(controllerListOptions)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	if len(s.Items) != 1 {
+		return microerror.Newf("unexpected number of services, want 1, got %d", len(s.Items))
+	}
+
+	return nil
 }
 
 func checkResourcesPresent(labelSelector string) error {
@@ -139,14 +166,6 @@ func checkResourcesPresent(labelSelector string) error {
 	}
 	if len(rb.Items) != 1 {
 		return microerror.Newf("unexpected number of rolebindings, want 1, got %d", len(rb.Items))
-	}
-
-	s, err := c.Core().Services(resourceNamespace).List(controllerListOptions)
-	if err != nil {
-		return microerror.Mask(err)
-	}
-	if len(s.Items) != 1 {
-		return microerror.Newf("unexpected number of services, want 1, got %d", len(s.Items))
 	}
 
 	sb, err := c.Core().Services(resourceNamespace).List(backendListOptions)
@@ -231,14 +250,6 @@ func checkResourcesNotPresent(labelSelector string) error {
 	rb, err := c.Rbac().RoleBindings(resourceNamespace).List(controllerListOptions)
 	if err == nil && len(rb.Items) > 0 {
 		return microerror.New("expected error querying for rolebindings didn't happen")
-	}
-	if !apierrors.IsNotFound(err) {
-		return microerror.Mask(err)
-	}
-
-	s, err := c.Core().Services(resourceNamespace).List(controllerListOptions)
-	if err == nil && len(s.Items) > 0 {
-		return microerror.New("expected error querying for services didn't happen")
 	}
 	if !apierrors.IsNotFound(err) {
 		return microerror.Mask(err)

--- a/integration/test/migration/migration_test.go
+++ b/integration/test/migration/migration_test.go
@@ -48,7 +48,7 @@ func TestMigration(t *testing.T) {
 
 	channel := fmt.Sprintf("%s-%s", env.CircleSHA(), testName)
 	releaseName := "kubernetes-nginx-ingress-controller"
-	err = r.InstallResource(releaseName, templates.NginxIngressControllerValues, channel)
+	err = r.InstallResource(releaseName, templates.NginxIngressControllerMigrationValues, channel)
 	if err != nil {
 		t.Fatalf("could not install %q %v", releaseName, err)
 	}


### PR DESCRIPTION
Towards giantswarm/giantswarm#3710

Adds an enabled flag for the migration job. This will be disabled on Azure and enabled for AWS and KVM.

Also updates the migration job so we don't delete the controller service.