### PR TITLE
Templating for role name

### DIFF
--- a/helm/kubernetes-nginx-ingress-controller-chart/Chart.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: v0.12.0
 description: A Helm chart for the nginx ingress-controller
 name: kubernetes-nginx-ingress-controller-chart
-version: 0.2.4
+version: 0.2.5

--- a/helm/kubernetes-nginx-ingress-controller-chart/templates/rbac.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/templates/rbac.yaml
@@ -30,7 +30,7 @@ subjects:
   namespace: {{ .Values.namespace }}
 roleRef:
   kind: Role
-  name: nginx-ingress-role
+  name: {{ .Values.controller.role.name }}
   apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -93,7 +93,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: nginx-ingress-role
+  name: {{ .Values.controller.role.name }}
   namespace: {{ .Values.namespace }}
   labels:
     app: {{ .Values.controller.name }}

--- a/helm/kubernetes-nginx-ingress-controller-chart/values.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/values.yaml
@@ -19,6 +19,9 @@ controller:
     repository: giantswarm/nginx-ingress-controller
     tag: 0.12.0
 
+  role:
+    name: nginx-ingress-role
+
   # Sets the NodePorts that maps to the Ingress' ports 80 (http) and 443 (https).
   service:
     enabled: true


### PR DESCRIPTION
Adds templating for the RBAC role name. So the temp resources can be installed during the migration.