### PR TITLE
Add structure for cleanup job

### DIFF
--- a/helm/kubernetes-nginx-ingress-controller-chart/Chart.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: v0.12.0
 description: A Helm chart for the nginx ingress-controller
 name: kubernetes-nginx-ingress-controller-chart
-version: 0.2.7
+version: 0.2.6

--- a/helm/kubernetes-nginx-ingress-controller-chart/Chart.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: v0.12.0
 description: A Helm chart for the nginx ingress-controller
 name: kubernetes-nginx-ingress-controller-chart
-version: 0.2.5
+version: 0.2.7

--- a/helm/kubernetes-nginx-ingress-controller-chart/charts/cleanup/Chart.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/charts/cleanup/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: 0.12.0
+description: A Helm chart for deleting temporary resources after migration of the Kubernetes ingress-controller service
+name: cleanup
+version: 0.1.0

--- a/helm/kubernetes-nginx-ingress-controller-chart/charts/cleanup/templates/configmap.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/charts/cleanup/templates/configmap.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.global.migration.job.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
+  annotations:
+    "helm.sh/hook": "post-install"
+    "helm.sh/hook-weight": "-2"
+    "helm.sh/hook-delete-policy": "hook-succeeded"
+  labels:
+    app: {{ .Values.name }}
+    giantswarm.io/service-type: "managed"
+data:
+  config.yaml: |
+    # TODO
+  values.json: |
+    {}
+{{- end }}

--- a/helm/kubernetes-nginx-ingress-controller-chart/charts/cleanup/templates/job.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/charts/cleanup/templates/job.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.global.migration.job.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
+  annotations:
+    "helm.sh/hook": "post-install"
+    "helm.sh/hook-delete-policy": "hook-succeeded"
+  labels:
+    app: {{ .Values.name }}
+    giantswarm.io/service-type: "managed"
+spec:
+  template:
+    spec:
+      volumes:
+      - name: {{ .Values.name }}
+        configMap:
+          name: {{ .Values.name }}
+          items:
+          - key: config.yaml
+            path: config.yaml
+          - key: values.json
+            path: values.json
+      serviceAccountName: {{ .Values.name }}
+      containers:
+      - name: {{ .Values.name }}
+        image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        volumeMounts:
+        - name: {{ .Values.name }}
+          mountPath: /var/run/{{ .Values.name }}/configmap/
+        args:
+        - delete
+        - -h
+        - --config.dirs=/var/run/{{ .Values.name }}/configmap/
+        - --config.files=config
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+      restartPolicy: Never
+  backoffLimit: 4
+{{- end }}

--- a/helm/kubernetes-nginx-ingress-controller-chart/charts/cleanup/templates/rbac.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/charts/cleanup/templates/rbac.yaml
@@ -1,0 +1,53 @@
+{{- if .Values.global.migration.job.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: {{ .Values.name }}
+  annotations:
+    "helm.sh/hook": "post-install"
+    "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-delete-policy": "hook-succeeded"
+  labels:
+    app: {{ .Values.name }}
+    giantswarm.io/service-type: "managed"
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - "list"
+- apiGroups:
+  - ""
+  resources:
+  - pods/portforward
+  verbs:
+  - "create"
+- apiGroups:
+  - extensions
+  resources:
+  - deployments
+  verbs:
+  - "get"
+  - "delete"
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Values.name }}
+  annotations:
+    "helm.sh/hook": "post-install"
+    "helm.sh/hook-weight": "-2"
+    "helm.sh/hook-delete-policy": "hook-succeeded"
+  labels:
+    app: {{ .Values.name }}
+    giantswarm.io/service-type: "managed"
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.name }}
+    namespace: {{ .Values.namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ .Values.name }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/helm/kubernetes-nginx-ingress-controller-chart/charts/cleanup/templates/service-account.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/charts/cleanup/templates/service-account.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.global.migration.job.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.name }}
+  annotations:
+    "helm.sh/hook": "post-install"
+    "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-delete-policy": "hook-succeeded"
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: {{ .Values.name }}
+    giantswarm.io/service-type: "managed"
+{{- end }}

--- a/helm/kubernetes-nginx-ingress-controller-chart/charts/cleanup/values.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/charts/cleanup/values.yaml
@@ -1,0 +1,23 @@
+# Default values for cleanup chart.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+name: ingress-controller-cleanup
+namespace: kube-system
+
+image:
+  registry: quay.io
+  repository: giantswarm/k8s-migrator
+  tag: latest
+
+cnr:
+  address: "https://quay.io"
+  organization: "giantswarm"
+
+resources:
+  limits:
+    cpu: 50m
+    memory: 75Mi
+  requests:
+    cpu: 50m
+    memory: 75Mi


### PR DESCRIPTION
Towards giantswarm/giantswarm#3710

Follow on from https://github.com/giantswarm/kubernetes-nginx-ingress-controller/pull/40 adds the structure for the cleanup job. This uses a post-install hook to delete the temp resources.

