### PR TITLE
Add cleanup job logic

### DIFF
--- a/helm/kubernetes-nginx-ingress-controller-chart/Chart.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: v0.12.0
 description: A Helm chart for the nginx ingress-controller
 name: kubernetes-nginx-ingress-controller-chart
-version: 0.2.7
+version: 0.2.8

--- a/helm/kubernetes-nginx-ingress-controller-chart/charts/cleanup/templates/configmap.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/charts/cleanup/templates/configmap.yaml
@@ -13,7 +13,23 @@ metadata:
     giantswarm.io/service-type: "managed"
 data:
   config.yaml: |
-    # TODO
-  values.json: |
-    {}
+   service:
+      cnr:
+        address: "{{ .Values.cnr.address }}"
+        organization: "{{ .Values.cnr.organization }}"
+      delete:
+        chart:
+          releaseName: "{{ .Values.delete.chart.releaseName }}"
+        wait:
+          deploymentName: "{{ .Values.delete.wait.deploymentName }}"
+          deploymentNamespace: "{{ .Values.namespace }}"
+      helm:
+        tillerNamespace: "{{ .Values.helm.tillerNamespace }}"
+      kubernetes:
+        address: ''
+        inCluster: true
+        tls:
+          caFile: ''
+          crtFile: ''
+          keyFile: ''
 {{- end }}

--- a/helm/kubernetes-nginx-ingress-controller-chart/charts/cleanup/templates/job.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/charts/cleanup/templates/job.yaml
@@ -20,8 +20,6 @@ spec:
           items:
           - key: config.yaml
             path: config.yaml
-          - key: values.json
-            path: values.json
       serviceAccountName: {{ .Values.name }}
       containers:
       - name: {{ .Values.name }}
@@ -31,7 +29,6 @@ spec:
           mountPath: /var/run/{{ .Values.name }}/configmap/
         args:
         - delete
-        - -h
         - --config.dirs=/var/run/{{ .Values.name }}/configmap/
         - --config.files=config
         resources:

--- a/helm/kubernetes-nginx-ingress-controller-chart/charts/cleanup/values.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/charts/cleanup/values.yaml
@@ -14,6 +14,15 @@ cnr:
   address: "https://quay.io"
   organization: "giantswarm"
 
+delete:
+  chart:
+    releaseName: "temp-nginx-ingress-controller"
+  wait:
+    deploymentName: "nginx-ingress-controller"
+
+helm:
+  tillerNamespace: "giantswarm"
+
 resources:
   limits:
     cpu: 50m


### PR DESCRIPTION
Towards giantswarm/giantswarm#3710

Implements the cleanup logic. Next PR will implement the logic for creating the temp resources.

Needs https://github.com/giantswarm/k8s-migrator/pull/22 first to make sure the cleanup job is idempotent.