### PR TITLE
Add temp resources job logic

### DIFF
--- a/helm/kubernetes-nginx-ingress-controller-chart/Chart.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: v0.12.0
 description: A Helm chart for the nginx ingress-controller
 name: kubernetes-nginx-ingress-controller-chart
-version: 0.2.8
+version: 0.2.9

--- a/helm/kubernetes-nginx-ingress-controller-chart/charts/cleanup/values.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/charts/cleanup/values.yaml
@@ -16,7 +16,7 @@ cnr:
 
 delete:
   chart:
-    releaseName: "ingress-controller-tempresources"
+    releaseName: "temp-nginx-ingress-controller"
   wait:
     deploymentName: "nginx-ingress-controller"
 

--- a/helm/kubernetes-nginx-ingress-controller-chart/charts/cleanup/values.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/charts/cleanup/values.yaml
@@ -16,7 +16,7 @@ cnr:
 
 delete:
   chart:
-    releaseName: "temp-nginx-ingress-controller"
+    releaseName: "ingress-controller-tempresources"
   wait:
     deploymentName: "nginx-ingress-controller"
 

--- a/helm/kubernetes-nginx-ingress-controller-chart/charts/migration/templates/configmap.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/charts/migration/templates/configmap.yaml
@@ -17,6 +17,9 @@ data:
       delete:
         resources:
           resourceFile: "/var/run/{{ .Values.name }}/configmap/resources.json"
+        wait:
+          deploymentName: "{{ .Values.delete.wait.deploymentName }}"
+          deploymentNamespace: "{{ .Values.namespace }}"
       kubernetes:
         address: ''
         inCluster: true

--- a/helm/kubernetes-nginx-ingress-controller-chart/charts/migration/values.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/charts/migration/values.yaml
@@ -10,6 +10,10 @@ image:
   repository: giantswarm/k8s-migrator
   tag: latest
 
+delete:
+  wait:
+    deploymentName: "temp-nginx-ingress-controller"
+
 resources:
   limits:
     cpu: 50m

--- a/helm/kubernetes-nginx-ingress-controller-chart/charts/tempresources/templates/configmap.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/charts/tempresources/templates/configmap.yaml
@@ -25,7 +25,7 @@ data:
           releaseName: "{{ .Values.create.chart.releaseName }}"
           valuesFile: "/var/run/{{ .Values.name }}/configmap/values.json"
       helm:
-        tillerNamespace:  "{{ .Values.namespace }}"
+        tillerNamespace:  "{{ .Values.helm.tillerNamespace }}"
       kubernetes:
         address: ''
         inCluster: true

--- a/helm/kubernetes-nginx-ingress-controller-chart/charts/tempresources/templates/configmap.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/charts/tempresources/templates/configmap.yaml
@@ -13,7 +13,47 @@ metadata:
     giantswarm.io/service-type: "managed"
 data:
   config.yaml: |
-    # TODO
+    service:
+      cnr:
+        address: "{{ .Values.cnr.address }}"
+        organization: "{{ .Values.cnr.organization }}"
+      create:
+        chart:
+          channelName: "{{ .Values.create.chart.channelName }}"
+          chartName: "{{ .Values.create.chart.chartName }}"
+          namespace: "{{ .Values.create.chart.namespace }}"
+          releaseName: "{{ .Values.create.chart.releaseName }}"
+          valuesFile: "/var/run/{{ .Values.name }}/configmap/values.json"
+      helm:
+        tillerNamespace:  "{{ .Values.namespace }}"
+      kubernetes:
+        address: ''
+        inCluster: true
+        tls:
+          caFile: ''
+          crtFile: ''
+          keyFile: ''
   values.json: |
-    {}
+    {
+      "controller": {
+        "name": "{{ .Values.controller.name }}",
+        "replicas": "{{ .Values.global.controller.replicas }}",
+        "configmap": {
+          "name": "{{ .Values.controller.configmap.name }}"
+        },
+        "role": {
+          "name": "{{ .Values.controller.role.name }}"
+        },
+        "service": {
+          "enabled": {{ .Values.controller.service.enabled }}
+        }
+      },
+      "defaultBackend": {
+        "name": "{{ .Values.defaultBackend.name }}"
+      },
+      "test": {
+        "enabled": false
+      }
+    }
+
 {{- end }}

--- a/helm/kubernetes-nginx-ingress-controller-chart/charts/tempresources/templates/job.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/charts/tempresources/templates/job.yaml
@@ -32,7 +32,6 @@ spec:
           mountPath: /var/run/{{ .Values.name }}/configmap/
         args:
         - create 
-        - -h
         - --config.dirs=/var/run/{{ .Values.name }}/configmap/
         - --config.files=config
         resources:

--- a/helm/kubernetes-nginx-ingress-controller-chart/charts/tempresources/values.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/charts/tempresources/values.yaml
@@ -33,8 +33,8 @@ controller:
   service:
     enabled: false
 
-  defaultBackend:
-    name: "temp-default-http-backend"
+defaultBackend:
+  name: "temp-default-http-backend"
 
 helm:
   tillerNamespace: "giantswarm"

--- a/helm/kubernetes-nginx-ingress-controller-chart/charts/tempresources/values.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/charts/tempresources/values.yaml
@@ -14,6 +14,31 @@ cnr:
   address: "https://quay.io"
   organization: "giantswarm"
 
+create:
+  chart:
+    chartName: "kubernetes-nginx-ingress-controller-chart"
+    channelName: "0-2-stable"
+    namespace: "kube-system"
+    releaseName: "temp-nginx-ingress-controller"
+
+controller:
+  name: "temp-nginx-ingress-controller"
+
+  configmap:
+    name: "temp-ingress-nginx"
+
+  role:
+    name: "temp-nginx-ingress-role"
+
+  service:
+    enabled: false
+
+  defaultBackend:
+    name: "temp-default-http-backend"
+
+helm:
+  tillerNamespace: "giantswarm"
+
 resources:
   limits:
     cpu: 50m

--- a/helm/kubernetes-nginx-ingress-controller-chart/values.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/values.yaml
@@ -59,6 +59,8 @@ defaultBackend:
 
 global:
   migration:
+    controller:
+      replicas: 3
     job:
       enabled: false
 

--- a/integration/templates/ingress_controller_migration_values.go
+++ b/integration/templates/ingress_controller_migration_values.go
@@ -10,7 +10,7 @@ controller:
   k8sAppLabel: nginx-ingress-controller
   metricsPort: 10254
 
-  replicas: 3
+  replicas: 1
 
   configmap:
     name: ingress-nginx
@@ -39,7 +39,7 @@ defaultBackend:
   k8sAppLabel: default-http-backend
   port: 8080
 
-  replicas: 2
+  replicas: 1
 
   image:
     registry: quay.io
@@ -55,6 +55,8 @@ defaultBackend:
       memory: 20Mi
 
 global:
+  controller:
+    replicas: 1
   migration:
     job:
       enabled: true


### PR DESCRIPTION
Towards giantswarm/giantswarm#3710

Installs the temp resources using k8s-migrator and waits for them to be ready before deleting the legacy k8scloudconfig resources.

Hopefully the comments explain what is going on. See https://github.com/giantswarm/giantswarm/issues/3710#issue-340304269 for more info on the overall approach. 