### PR TITLE
Templating for privileged PSP user

### DIFF
--- a/helm/kubernetes-nginx-ingress-controller-chart/Chart.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: v0.12.0
 description: A Helm chart for the nginx ingress-controller
 name: kubernetes-nginx-ingress-controller-chart
-version: 0.2.10
+version: 0.2.11

--- a/helm/kubernetes-nginx-ingress-controller-chart/templates/rbac.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/templates/rbac.yaml
@@ -15,6 +15,23 @@ roleRef:
   name: {{ .Values.controller.name }}
   apiGroup: rbac.authorization.k8s.io
 ---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Values.controller.name }}-privileged-psp
+  labels:
+    app: {{ .Values.controller.name }}
+    giantswarm.io/service-type: "managed"
+    k8s-app: {{ .Values.controller.k8sAppLabel }}
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.controller.name }}
+  namespace: {{ .Values.namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ .Values.controller.rbac.privilegedPod.role.name }}
+  apiGroup: rbac.authorization.k8s.io
+---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/helm/kubernetes-nginx-ingress-controller-chart/values.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/values.yaml
@@ -19,6 +19,11 @@ controller:
     repository: giantswarm/nginx-ingress-controller
     tag: 0.12.0
 
+  rbac:
+    privilegedPod:
+      role:
+        name: privileged-psp-user 
+
   role:
     name: nginx-ingress-role
 

--- a/integration/test/migration/migration_test.go
+++ b/integration/test/migration/migration_test.go
@@ -163,8 +163,8 @@ func checkResourcesPresent(labelSelector string) error {
 	if err != nil {
 		return microerror.Mask(err)
 	}
-	if len(rb.Items) != 1 {
-		return microerror.Newf("unexpected number of rolebindings, want 1, got %d", len(rb.Items))
+	if len(rb.Items) != 2 {
+		return microerror.Newf("unexpected number of rolebindings, want 2, got %d", len(rb.Items))
 	}
 
 	sb, err := c.Core().Services(resourceNamespace).List(backendListOptions)

--- a/integration/test/migration/migration_test.go
+++ b/integration/test/migration/migration_test.go
@@ -159,12 +159,18 @@ func checkResourcesPresent(labelSelector string) error {
 		return microerror.Newf("unexpected number of roles, want 1, got %d", len(r.Items))
 	}
 
+	// An adddional role binding is needed for the chart due to the migration.
+	roleBindingCount := 1
+	if labelSelector == "giantswarm.io/service-type=managed" {
+		roleBindingCount = 2
+	}
+
 	rb, err := c.Rbac().RoleBindings(resourceNamespace).List(controllerListOptions)
 	if err != nil {
 		return microerror.Mask(err)
 	}
-	if len(rb.Items) != 2 {
-		return microerror.Newf("unexpected number of rolebindings, want 2, got %d", len(rb.Items))
+	if len(rb.Items) != roleBindingCount {
+		return microerror.Newf("unexpected number of rolebindings, want %d, got %d", roleBindingCount, len(rb.Items))
 	}
 
 	sb, err := c.Core().Services(resourceNamespace).List(backendListOptions)

--- a/integration/test/migration/migration_test.go
+++ b/integration/test/migration/migration_test.go
@@ -143,12 +143,18 @@ func checkResourcesPresent(labelSelector string) error {
 		return microerror.Newf("unexpected number of roles, want 1, got %d", len(cr.Items))
 	}
 
+	// An extra cluster role binding is needed by the chart due to the migration.
+	clusterRoleBindingCount := 1
+	if labelSelector == "giantswarm.io/service-type=managed" {
+		clusterRoleBindingCount = 2
+	}
+
 	crb, err := c.Rbac().ClusterRoleBindings().List(controllerListOptions)
 	if err != nil {
 		return microerror.Mask(err)
 	}
-	if len(crb.Items) != 1 {
-		return microerror.Newf("unexpected number of rolebindings, want 1, got %d", len(crb.Items))
+	if len(crb.Items) != clusterRoleBindingCount {
+		return microerror.Newf("unexpected number of cluster rolebindings, want %d, got %d", clusterRoleBindingCount, len(crb.Items))
 	}
 
 	r, err := c.Rbac().Roles(resourceNamespace).List(controllerListOptions)
@@ -159,18 +165,12 @@ func checkResourcesPresent(labelSelector string) error {
 		return microerror.Newf("unexpected number of roles, want 1, got %d", len(r.Items))
 	}
 
-	// An adddional role binding is needed for the chart due to the migration.
-	roleBindingCount := 1
-	if labelSelector == "giantswarm.io/service-type=managed" {
-		roleBindingCount = 2
-	}
-
 	rb, err := c.Rbac().RoleBindings(resourceNamespace).List(controllerListOptions)
 	if err != nil {
 		return microerror.Mask(err)
 	}
-	if len(rb.Items) != roleBindingCount {
-		return microerror.Newf("unexpected number of rolebindings, want %d, got %d", roleBindingCount, len(rb.Items))
+	if len(rb.Items) != 1 {
+		return microerror.Newf("unexpected number of rolebindings, want 1, got %d", len(rb.Items))
 	}
 
 	sb, err := c.Core().Services(resourceNamespace).List(backendListOptions)
@@ -188,7 +188,6 @@ func checkResourcesPresent(labelSelector string) error {
 	if len(sa.Items) != 1 {
 		return microerror.Newf("unexpected number of serviceaccountss, want 1, got %d", len(sa.Items))
 	}
-
 	return nil
 }
 


### PR DESCRIPTION
Towards giantswarm/giantswarm#3710

The IC controller pods need privileged access. Currently this is granted for the `nginx-ingress-controller` service account in k8scloudconfig.

https://github.com/giantswarm/k8scloudconfig/blob/f40dfaefc463529f418c9177e0983f4955505a13/v_3_5_0/master_template.go#L1271-L1273

For the migration when installing the temp resources the service account is `temp-nginx-ingress-controller` so the pods can't be created. This adds templating to create the cluster role binding to the chart.

Moving the templating here makes the chart more self contained. It still relies on k8scc to create the `privileged-psp-user` cluster role.


