### PR TITLE
Simplify migration flag

### DIFF
--- a/helm/kubernetes-nginx-ingress-controller-chart/Chart.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: v0.12.0
 description: A Helm chart for the nginx ingress-controller
 name: kubernetes-nginx-ingress-controller-chart
-version: 0.2.11
+version: 0.2.12

--- a/helm/kubernetes-nginx-ingress-controller-chart/charts/cleanup/templates/configmap.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/charts/cleanup/templates/configmap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.global.migration.job.enabled }}
+{{- if .Values.global.migration.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/helm/kubernetes-nginx-ingress-controller-chart/charts/cleanup/templates/job.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/charts/cleanup/templates/job.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.global.migration.job.enabled }}
+{{- if .Values.global.migration.enabled }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/helm/kubernetes-nginx-ingress-controller-chart/charts/cleanup/templates/rbac.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/charts/cleanup/templates/rbac.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.global.migration.job.enabled }}
+{{- if .Values.global.migration.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:

--- a/helm/kubernetes-nginx-ingress-controller-chart/charts/cleanup/templates/service-account.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/charts/cleanup/templates/service-account.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.global.migration.job.enabled }}
+{{- if .Values.global.migration.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/helm/kubernetes-nginx-ingress-controller-chart/charts/migration/templates/configmap.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/charts/migration/templates/configmap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.global.migration.job.enabled }}
+{{- if .Values.global.migration.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/helm/kubernetes-nginx-ingress-controller-chart/charts/migration/templates/job.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/charts/migration/templates/job.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.global.migration.job.enabled }}
+{{- if .Values.global.migration.enabled }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/helm/kubernetes-nginx-ingress-controller-chart/charts/migration/templates/rbac.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/charts/migration/templates/rbac.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.global.migration.job.enabled }}
+{{- if .Values.global.migration.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:

--- a/helm/kubernetes-nginx-ingress-controller-chart/charts/migration/templates/service-account.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/charts/migration/templates/service-account.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.global.migration.job.enabled }}
+{{- if .Values.global.migration.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/helm/kubernetes-nginx-ingress-controller-chart/charts/tempresources/templates/configmap.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/charts/tempresources/templates/configmap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.global.migration.job.enabled }}
+{{- if .Values.global.migration.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/helm/kubernetes-nginx-ingress-controller-chart/charts/tempresources/templates/job.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/charts/tempresources/templates/job.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.global.migration.job.enabled }}
+{{- if .Values.global.migration.enabled }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/helm/kubernetes-nginx-ingress-controller-chart/charts/tempresources/templates/rbac.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/charts/tempresources/templates/rbac.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.global.migration.job.enabled }}
+{{- if .Values.global.migration.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:

--- a/helm/kubernetes-nginx-ingress-controller-chart/charts/tempresources/templates/service-account.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/charts/tempresources/templates/service-account.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.global.migration.job.enabled }}
+{{- if .Values.global.migration.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/helm/kubernetes-nginx-ingress-controller-chart/templates/controller-deployment.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/templates/controller-deployment.yaml
@@ -57,7 +57,7 @@ spec:
           privileged: true
       containers:
       - name: {{ .Values.controller.name }}
-        image: "{{ .Values.controller.image.registry }}/{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"
+        image: "{{ .Values.image.registry }}/{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"
         args:
         - /nginx-ingress-controller
         - --default-backend-service=$(POD_NAMESPACE)/{{ .Values.defaultBackend.name }}

--- a/helm/kubernetes-nginx-ingress-controller-chart/templates/controller-service.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/templates/controller-service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.controller.service.enabled }}
+{{- if eq .Values.global.migration.enabled false }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/helm/kubernetes-nginx-ingress-controller-chart/templates/default-backend-deployment.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/templates/default-backend-deployment.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
       - name: {{ .Values.defaultBackend.name }}
-        image: "{{ .Values.defaultBackend.image.registry }}/{{ .Values.defaultBackend.image.repository }}:{{ .Values.defaultBackend.image.tag }}"
+        image: "{{ .Values.image.registry }}/{{ .Values.defaultBackend.image.repository }}:{{ .Values.defaultBackend.image.tag }}"
         livenessProbe:
           httpGet:
             path: /healthz

--- a/helm/kubernetes-nginx-ingress-controller-chart/values.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/values.yaml
@@ -29,7 +29,6 @@ controller:
 
   # Sets the NodePorts that maps to the Ingress' ports 80 (http) and 443 (https).
   service:
-    enabled: true
     nodePorts:
       http: 30010
       https: 30011

--- a/helm/kubernetes-nginx-ingress-controller-chart/values.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/values.yaml
@@ -15,7 +15,6 @@ controller:
     name: ingress-nginx
 
   image:
-    registry: quay.io
     repository: giantswarm/nginx-ingress-controller
     tag: 0.12.0
 
@@ -49,7 +48,6 @@ defaultBackend:
   replicas: 2
 
   image:
-    registry: quay.io
     repository: giantswarm/defaultbackend
     tag: 1.2
 
@@ -60,6 +58,10 @@ defaultBackend:
     requests:
       cpu: 10m
       memory: 20Mi
+
+image:
+  registry: quay.io
+
 
 global:
   controller:

--- a/helm/kubernetes-nginx-ingress-controller-chart/values.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/values.yaml
@@ -63,11 +63,10 @@ defaultBackend:
       memory: 20Mi
 
 global:
+  controller:
+    replicas: 3
   migration:
-    controller:
-      replicas: 3
-    job:
-      enabled: false
+    enabled: false
 
 initContainer:
   image:

--- a/integration/templates/ingress_controller_basic_values.go
+++ b/integration/templates/ingress_controller_basic_values.go
@@ -16,12 +16,10 @@ controller:
     name: ingress-nginx
 
   image:
-    registry: quay.io
     repository: giantswarm/nginx-ingress-controller
     tag: 0.12.0
 
   service:
-    enabled: true
     nodePorts:
       http: 30010
       https: 30011
@@ -42,7 +40,6 @@ defaultBackend:
   replicas: 2
 
   image:
-    registry: quay.io
     repository: giantswarm/defaultbackend
     tag: 1.2
 
@@ -56,8 +53,10 @@ defaultBackend:
 
 global:
   migration:
-    job:
-      enabled: false
+    enabled: false
+
+image:
+  registry: quay.io
 
 initContainer:
   image:

--- a/integration/templates/ingress_controller_migration_values.go
+++ b/integration/templates/ingress_controller_migration_values.go
@@ -16,12 +16,10 @@ controller:
     name: ingress-nginx
 
   image:
-    registry: quay.io
     repository: giantswarm/nginx-ingress-controller
     tag: 0.12.0
 
   service:
-    enabled: false
     nodePorts:
       http: 30010
       https: 30011
@@ -42,7 +40,6 @@ defaultBackend:
   replicas: 1
 
   image:
-    registry: quay.io
     repository: giantswarm/defaultbackend
     tag: 1.2
 
@@ -58,8 +55,10 @@ global:
   controller:
     replicas: 1
   migration:
-    job:
-      enabled: true
+    enabled: true
+
+image:
+  registry: quay.io
 
 initContainer:
   image:


### PR DESCRIPTION
See https://github.com/giantswarm/cluster-operator/pull/211#discussion_r209958873 

Simplifies the templating and cluster-operator changes by using a single flag for the migration.