### PR TITLE
Controller settings for migration

### DIFF
--- a/helm/kubernetes-nginx-ingress-controller-chart/Chart.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: v0.12.0
 description: A Helm chart for the nginx ingress-controller
 name: kubernetes-nginx-ingress-controller-chart
-version: 0.2.13
+version: 0.2.15

--- a/helm/kubernetes-nginx-ingress-controller-chart/charts/tempresources/templates/configmap.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/charts/tempresources/templates/configmap.yaml
@@ -43,12 +43,18 @@ data:
         },
         "role": {
           "name": "{{ .Values.controller.role.name }}"
-        }
+        },
+        "service": {
+          "enabled": false,
+        },
       },
       "defaultBackend": {
         "name": "{{ .Values.defaultBackend.name }}"
       },
       "global": {
+        "controller": {
+          "useProxyProtocol": {{ .Values.global.controller.useProxyProtocol }}
+        },
         "migration": {
           "enabled": false
         }

--- a/helm/kubernetes-nginx-ingress-controller-chart/templates/configmap.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/templates/configmap.yaml
@@ -16,3 +16,4 @@ data:
   # Disables setting a 'Strict-Transport-Security' header, which can be harmful.
   # See https://github.com/kubernetes/ingress-nginx/issues/549#issuecomment-291894246
   hsts: "false"
+  use-proxy-protocol: "{{ .Values.global.controller.useProxyProtocol }}"

--- a/helm/kubernetes-nginx-ingress-controller-chart/templates/controller-service.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/templates/controller-service.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.global.migration.enabled false }}
+{{- if .Values.controller.service.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/helm/kubernetes-nginx-ingress-controller-chart/values.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/values.yaml
@@ -28,6 +28,7 @@ controller:
 
   # Sets the NodePorts that maps to the Ingress' ports 80 (http) and 443 (https).
   service:
+    enabled: true
     nodePorts:
       http: 30010
       https: 30011

--- a/helm/kubernetes-nginx-ingress-controller-chart/values.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/values.yaml
@@ -66,6 +66,7 @@ image:
 global:
   controller:
     replicas: 3
+    useProxyProtocol: false
   migration:
     enabled: false
 

--- a/integration/templates/ingress_controller_basic_values.go
+++ b/integration/templates/ingress_controller_basic_values.go
@@ -20,6 +20,7 @@ controller:
     tag: 0.12.0
 
   service:
+    enabled: true
     nodePorts:
       http: 30010
       https: 30011
@@ -52,6 +53,8 @@ defaultBackend:
       memory: 20Mi
 
 global:
+  controller:
+    useProxyProtocol: false
   migration:
     enabled: false
 

--- a/integration/templates/ingress_controller_migration_values.go
+++ b/integration/templates/ingress_controller_migration_values.go
@@ -20,6 +20,8 @@ controller:
     tag: 0.12.0
 
   service:
+    service:
+      enabled: false
     nodePorts:
       http: 30010
       https: 30011
@@ -54,6 +56,7 @@ defaultBackend:
 global:
   controller:
     replicas: 1
+    useProxyProtocol: true
   migration:
     enabled: true
 

--- a/integration/templates/ingress_controller_migration_values.go
+++ b/integration/templates/ingress_controller_migration_values.go
@@ -20,8 +20,7 @@ controller:
     tag: 0.12.0
 
   service:
-    service:
-      enabled: false
+    enabled: false
     nodePorts:
       http: 30010
       https: 30011


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/3710

Adds 2 additional settings to the chart that are needed for the migration. 

- Use Proxy Protocol is used to enable it on AWS. Currently we overwrite the ingress controller configmap in aws-operator. https://github.com/giantswarm/aws-operator/blob/1b16539b73cde4923aad85ddd8640cfcc8371e90/service/controller/v15/templates/cloudconfig/ingress_controller_config_map.go
- Service enabled flag is needed for installing the temp resources.