### PR TITLE
Temp replicas

### DIFF
--- a/helm/kubernetes-nginx-ingress-controller-chart/Chart.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: v0.12.0
 description: A Helm chart for the nginx ingress-controller
 name: kubernetes-nginx-ingress-controller-chart
-version: 0.2.15
+version: 0.2.16

--- a/helm/kubernetes-nginx-ingress-controller-chart/charts/tempresources/templates/configmap.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/charts/tempresources/templates/configmap.yaml
@@ -37,7 +37,7 @@ data:
     {
       "controller": {
         "name": "{{ .Values.controller.name }}",
-        "replicas": "{{ .Values.global.controller.replicas }}",
+        "replicas": "{{ .Values.global.controller.tempReplicas }}",
         "configmap": {
           "name": "{{ .Values.controller.configmap.name }}"
         },

--- a/helm/kubernetes-nginx-ingress-controller-chart/values.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/values.yaml
@@ -66,7 +66,7 @@ image:
 
 global:
   controller:
-    replicas: 3
+    tempReplicas: 2
     useProxyProtocol: false
   migration:
     enabled: false

--- a/integration/templates/ingress_controller_migration_values.go
+++ b/integration/templates/ingress_controller_migration_values.go
@@ -54,7 +54,7 @@ defaultBackend:
 
 global:
   controller:
-    replicas: 1
+    tempReplicas: 1
     useProxyProtocol: true
   migration:
     enabled: true


### PR DESCRIPTION
Renamed global.controller.replicas to tempReplicas to make the name clearer.

See https://github.com/giantswarm/cluster-operator/pull/220/files for related cluster-operator change.