### PR TITLE
Set priority class for controller pods

### DIFF
--- a/helm/kubernetes-nginx-ingress-controller-chart/Chart.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: v0.15.0
 description: A Helm chart for the nginx ingress-controller
 name: kubernetes-nginx-ingress-controller-chart
-version: 0.2.16
+version: 0.2.17

--- a/helm/kubernetes-nginx-ingress-controller-chart/templates/controller-deployment.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/templates/controller-deployment.yaml
@@ -43,6 +43,7 @@ spec:
                   - {{ .Values.controller.name }}
               topologyKey: kubernetes.io/hostname
       serviceAccountName: {{ .Values.controller.name }}
+      priorityClassName: system-cluster-critical
       initContainers:
       # Overall performance improvements
       # See https://github.com/kubernetes/ingress-nginx/issues/1939


### PR DESCRIPTION
Sets the priority class name. This was added to k8scloudconfig but didn't get added to the chart.

It will also deploy the ingress controller upgrade to 0.15.0. The chart version didn't get incremented on Friday so this wasn't deployed.

We need a way to auto update the chart version or at least fail CI if it hasn't been incremented. I want to tackle that this week.

