### PR TITLE
Extend configmap templating for custom configmaps

### DIFF
--- a/helm/kubernetes-nginx-ingress-controller-chart/Chart.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: v0.15.0
 description: A Helm chart for the nginx ingress-controller
 name: kubernetes-nginx-ingress-controller-chart
-version: 0.2.17
+version: 0.3.0

--- a/helm/kubernetes-nginx-ingress-controller-chart/templates/configmap.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/templates/configmap.yaml
@@ -7,10 +7,23 @@ metadata:
     giantswarm.io/service-type: "managed"
     k8s-addon: ingress-nginx.addons.k8s.io
 data:
+  {{- if .Values.configmap.enable-underscores-in-headers }}
+  enable-underscores-in-headers: "{{.Values.configmap.enable-underscores-in-headers }}"
+  {{- end}}
+
   enable-vts-status: "{{ .Values.configmap.enable-vts-status }}"
   # Disables setting a 'Strict-Transport-Security' header, which can be harmful.
   # See https://github.com/kubernetes/ingress-nginx/issues/549#issuecomment-291894246
   hsts: "{{ .Values.configmap.hsts }}"
+
+  {{- if .Values.configmap.proxy-buffers-size }}
+  proxy-buffers-size: "{{.Values.configmap.proxy-buffers-size }}"
+  {{- end}}
+
+  {{- if .Values.configmap.proxy-buffers }}
+  proxy-buffers: "{{.Values.configmap.proxy-buffers }}"
+  {{- end}}
+
   # Increase hash table size to allow more server names for stability reasons
   server-name-hash-bucket-size: "{{ .Values.configmap.server-name-hash-bucket-size }}"
   server-name-hash-max-size: "{{ .Values.configmap.server-name-hash-max-size }}"
@@ -18,3 +31,7 @@ data:
   worker-processes: "{{ .Values.configmap.worker-processes }}"
   # Global is used as this key is used by the migration logic.
   use-proxy-protocol: "{{ .Values.global.controller.useProxyProtocol }}"
+
+  {{- if .Values.configmap.vts-default-filter-key }}
+  vts-default-filter-key: "{{.Values.configmap.vts-default-filter-key }}"
+  {{- end}}

--- a/helm/kubernetes-nginx-ingress-controller-chart/templates/configmap.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/templates/configmap.yaml
@@ -15,6 +15,6 @@ data:
   server-name-hash-bucket-size: "{{ .Values.configmap.server-name-hash-bucket-size }}"
   server-name-hash-max-size: "{{ .Values.configmap.server-name-hash-max-size }}"
   server-tokens: "{{ .Values.configmap.server-tokens }}"
-  worker-processes: "4"
+  worker-processes: "{{ .Values.configmap.worker-processes }}"
   # Global is used as this key is used by the migration logic.
   use-proxy-protocol: "{{ .Values.global.controller.useProxyProtocol }}"

--- a/helm/kubernetes-nginx-ingress-controller-chart/templates/configmap.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/templates/configmap.yaml
@@ -7,13 +7,14 @@ metadata:
     giantswarm.io/service-type: "managed"
     k8s-addon: ingress-nginx.addons.k8s.io
 data:
-  enable-vts-status: "true"
-  # Increase hash table size to allow more server names for stability reasons
-  server-name-hash-bucket-size: "1024"
-  server-name-hash-max-size: "1024"
-  server-tokens: "false"
-  worker-processes: "4"
+  enable-vts-status: "{{ .Values.configmap.enable-vts-status }}"
   # Disables setting a 'Strict-Transport-Security' header, which can be harmful.
   # See https://github.com/kubernetes/ingress-nginx/issues/549#issuecomment-291894246
-  hsts: "false"
+  hsts: "{{ .Values.configmap.hsts }}"
+  # Increase hash table size to allow more server names for stability reasons
+  server-name-hash-bucket-size: "{{ .Values.configmap.server-name-hash-bucket-size }}"
+  server-name-hash-max-size: "{{ .Values.configmap.server-name-hash-max-size }}"
+  server-tokens: "{{ .Values.configmap.server-tokens }}"
+  worker-processes: "4"
+  # Global is used as this key is used by the migration logic.
   use-proxy-protocol: "{{ .Values.global.controller.useProxyProtocol }}"

--- a/helm/kubernetes-nginx-ingress-controller-chart/values.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/values.yaml
@@ -4,6 +4,17 @@
 
 namespace: kube-system
 
+# configmap contains settings that can be overridden with a custom values
+# configmap.
+configmap:
+  enable-vts-status: "true"
+  server-name-hash-bucket-size: "1024"
+  server-name-hash-max-size: "1024"
+  server-tokens: "false"
+  worker-processes: "4"
+  hsts: "false"
+  use-proxy-protocol: false
+
 controller:
   name: nginx-ingress-controller
   k8sAppLabel: nginx-ingress-controller

--- a/helm/kubernetes-nginx-ingress-controller-chart/values.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/values.yaml
@@ -8,12 +8,11 @@ namespace: kube-system
 # configmap.
 configmap:
   enable-vts-status: "true"
+  hsts: "false"
   server-name-hash-bucket-size: "1024"
   server-name-hash-max-size: "1024"
   server-tokens: "false"
   worker-processes: "4"
-  hsts: "false"
-  use-proxy-protocol: false
 
 controller:
   name: nginx-ingress-controller

--- a/helm/kubernetes-nginx-ingress-controller-chart/values.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/values.yaml
@@ -14,6 +14,12 @@ configmap:
   server-tokens: "false"
   worker-processes: "4"
 
+  # optional settings that can be set.
+  enable-underscores-in-headers: ""
+  proxy-buffers-size: ""
+  proxy-buffers: ""
+  vts-default-filter-key: ""
+
 controller:
   name: nginx-ingress-controller
   k8sAppLabel: nginx-ingress-controller


### PR DESCRIPTION
Towards giantswarm/giantswarm#4093

Adds more templating for the ingress confiigmap. Customers will be able to change these settings by creating a custom configmap.

The settings added are currently changed in viking by editing the ingress configmap manually after it has been deployed.