### PR TITLE
Templating fixes and updated test wiring

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -163,7 +163,7 @@
     "chart",
     "chart/env"
   ]
-  revision = "d69cd345fbb3e1b1c7f092cf009d0c92806ce2bb"
+  revision = "649469c2d54fba4bf86b3e9bca96bd47435461ae"
 
 [[projects]]
   branch = "master"

--- a/helm/kubernetes-nginx-ingress-controller-chart/Chart.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: v0.15.0
 description: A Helm chart for the nginx ingress-controller
 name: kubernetes-nginx-ingress-controller-chart
-version: 0.3.0
+version: 0.3.1

--- a/helm/kubernetes-nginx-ingress-controller-chart/templates/configmap.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/templates/configmap.yaml
@@ -7,31 +7,30 @@ metadata:
     giantswarm.io/service-type: "managed"
     k8s-addon: ingress-nginx.addons.k8s.io
 data:
-  {{- if .Values.configmap.enable-underscores-in-headers }}
-  enable-underscores-in-headers: "{{.Values.configmap.enable-underscores-in-headers }}"
+  {{- if index .Values.configmap "enable-underscores-in-headers" }}
+  enable-underscores-in-headers: "{{ index .Values.configmap "enable-underscores-in-headers" }}"
   {{- end}}
-
-  enable-vts-status: "{{ .Values.configmap.enable-vts-status }}"
+  enable-vts-status: "{{ index .Values.configmap "enable-vts-status" }}"
   # Disables setting a 'Strict-Transport-Security' header, which can be harmful.
   # See https://github.com/kubernetes/ingress-nginx/issues/549#issuecomment-291894246
   hsts: "{{ .Values.configmap.hsts }}"
 
-  {{- if .Values.configmap.proxy-buffers-size }}
-  proxy-buffers-size: "{{.Values.configmap.proxy-buffers-size }}"
+  {{- if index .Values.configmap "proxy-buffers-size" }}
+  proxy-buffers-size: "{{ index .Values.configmap "proxy-buffers-size" }}"
   {{- end}}
 
-  {{- if .Values.configmap.proxy-buffers }}
-  proxy-buffers: "{{.Values.configmap.proxy-buffers }}"
+  {{- if index .Values.configmap "proxy-buffers" }}
+  proxy-buffers: "{{ index .Values.configmap "proxy-buffers" }}"
   {{- end}}
 
   # Increase hash table size to allow more server names for stability reasons
-  server-name-hash-bucket-size: "{{ .Values.configmap.server-name-hash-bucket-size }}"
-  server-name-hash-max-size: "{{ .Values.configmap.server-name-hash-max-size }}"
-  server-tokens: "{{ .Values.configmap.server-tokens }}"
-  worker-processes: "{{ .Values.configmap.worker-processes }}"
+  server-name-hash-bucket-size: "{{ index .Values.configmap "server-name-hash-bucket-size" }}"
+  server-name-hash-max-size: "{{ index .Values.configmap "server-name-hash-max-size" }}"
+  server-tokens: "{{ index .Values.configmap "server-tokens" }}"
+  worker-processes: "{{ index .Values.configmap "worker-processes" }}"
   # Global is used as this key is used by the migration logic.
   use-proxy-protocol: "{{ .Values.global.controller.useProxyProtocol }}"
 
-  {{- if .Values.configmap.vts-default-filter-key }}
-  vts-default-filter-key: "{{.Values.configmap.vts-default-filter-key }}"
+  {{- if index .Values.configmap "vts-default-filter-key" }}
+  vts-default-filter-key: "{{ index .Values.configmap "vts-default-filter-key" }}"
   {{- end}}

--- a/integration/test/basic/main_test.go
+++ b/integration/test/basic/main_test.go
@@ -64,9 +64,10 @@ func init() {
 
 	{
 		c := framework.HostConfig{
-			Logger:     l,
-			ClusterID:  "na",
-			VaultToken: "na",
+			Logger: l,
+
+			ClusterID:  "n/a",
+			VaultToken: "n/a",
 		}
 		h, err = framework.NewHost(c)
 		if err != nil {
@@ -76,9 +77,10 @@ func init() {
 
 	{
 		c := helmclient.Config{
-			Logger:          l,
-			K8sClient:       h.K8sClient(),
-			RestConfig:      h.RestConfig(),
+			Logger:     l,
+			K8sClient:  h.K8sClient(),
+			RestConfig: h.RestConfig(),
+
 			TillerNamespace: "giantswarm",
 		}
 		helmClient, err = helmclient.New(c)
@@ -150,10 +152,11 @@ func TestMain(m *testing.M) {
 			Host:       h,
 		}
 
-		err := e2esetup.Setup(ctx, m, c)
+		v, err := e2esetup.Setup(ctx, m, c)
 		if err != nil {
 			l.LogCtx(ctx, "level", "error", "message", "e2e test failed", "stack", fmt.Sprintf("%#v\n", err))
-			os.Exit(1)
 		}
+
+		os.Exit(v)
 	}
 }

--- a/integration/test/migration/main_test.go
+++ b/integration/test/migration/main_test.go
@@ -85,10 +85,11 @@ func TestMain(m *testing.M) {
 			Host:       h,
 		}
 
-		err := e2esetup.Setup(ctx, m, c)
+		v, err := e2esetup.Setup(ctx, m, c)
 		if err != nil {
 			l.LogCtx(ctx, "level", "error", "message", "e2e test failed", "stack", fmt.Sprintf("%#v\n", err))
-			os.Exit(1)
 		}
+
+		os.Exit(v)
 	}
 }

--- a/vendor/github.com/giantswarm/e2esetup/chart/setup.go
+++ b/vendor/github.com/giantswarm/e2esetup/chart/setup.go
@@ -9,16 +9,16 @@ import (
 	"github.com/giantswarm/e2esetup/chart/env"
 )
 
-func Setup(ctx context.Context, m *testing.M, config Config) error {
+func Setup(ctx context.Context, m *testing.M, config Config) (int, error) {
 	var v int
 	var err error
 	var errors []error
 
 	if config.HelmClient == nil {
-		return microerror.Maskf(invalidConfigError, "%T.HelmClient must not be empty", config)
+		return v, microerror.Maskf(invalidConfigError, "%T.HelmClient must not be empty", config)
 	}
 	if config.Host == nil {
-		return microerror.Maskf(invalidConfigError, "%T.Host must not be empty", config)
+		return v, microerror.Maskf(invalidConfigError, "%T.Host must not be empty", config)
 	}
 
 	err = config.Host.CreateNamespace("giantswarm")
@@ -51,8 +51,8 @@ func Setup(ctx context.Context, m *testing.M, config Config) error {
 	}
 
 	if len(errors) > 0 {
-		return microerror.Mask(errors[0])
+		return v, microerror.Mask(errors[0])
 	}
 
-	return nil
+	return v, nil
 }


### PR DESCRIPTION
Fixing the test wiring highlighted a problem with the templating. The index function needs to be used for the templating because of underscores in the key names. No tenant clusters are affected because change uses the `0-3-stable` release channel which isn't active yet.


