### PR TITLE
Increase limits for controller resources

### DIFF
--- a/helm/kubernetes-nginx-ingress-controller-chart/Chart.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: v0.15.0
 description: A Helm chart for the nginx ingress-controller
 name: kubernetes-nginx-ingress-controller-chart
-version: 0.3.1
+version: 0.3.2

--- a/helm/kubernetes-nginx-ingress-controller-chart/values.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/values.yaml
@@ -50,9 +50,12 @@ controller:
       https: 30011
 
   resources:
+    limits:
+      cpu: 500m
+      memory: 600Mi
     requests:
       cpu: 500m
-      memory: 350Mi
+      memory: 600Mi
 
 defaultBackend:
   name: default-http-backend

--- a/helm/kubernetes-nginx-ingress-controller-chart/values.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/values.yaml
@@ -50,9 +50,6 @@ controller:
       https: 30011
 
   resources:
-    limits:
-      cpu: 500m
-      memory: 350Mi
     requests:
       cpu: 500m
       memory: 350Mi


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/4177

Limits were added to the values.yaml but these are not present in the k8scloudconfig manifests. ~~Removing as this is causing OOM errors in production clusters.~~

EDIT: Limits updated to match values manually applied in `asgard`.

```
  resources:
    limits:
      cpu: 500m
      memory: 600Mi
    requests:
      cpu: 500m
      memory: 600Mi
```