### PR TITLE
 Update helm delete policy to prevent errors on retries

### DIFF
--- a/helm/kubernetes-nginx-ingress-controller-chart/Chart.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: v0.15.0
 description: A Helm chart for the nginx ingress-controller
 name: kubernetes-nginx-ingress-controller-chart
-version: 0.3.2
+version: 0.3.3

--- a/helm/kubernetes-nginx-ingress-controller-chart/charts/cleanup/templates/configmap.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/charts/cleanup/templates/configmap.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     "helm.sh/hook": "post-install"
     "helm.sh/hook-weight": "-2"
-    "helm.sh/hook-delete-policy": "hook-succeeded"
+    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
   labels:
     app: {{ .Values.name }}
     giantswarm.io/service-type: "managed"

--- a/helm/kubernetes-nginx-ingress-controller-chart/charts/cleanup/templates/rbac.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/charts/cleanup/templates/rbac.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     "helm.sh/hook": "post-install"
     "helm.sh/hook-weight": "-1"
-    "helm.sh/hook-delete-policy": "hook-succeeded"
+    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
   labels:
     app: {{ .Values.name }}
     giantswarm.io/service-type: "managed"

--- a/helm/kubernetes-nginx-ingress-controller-chart/charts/cleanup/templates/service-account.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/charts/cleanup/templates/service-account.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     "helm.sh/hook": "post-install"
     "helm.sh/hook-weight": "-1"
-    "helm.sh/hook-delete-policy": "hook-succeeded"
+    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
   namespace: {{ .Values.namespace }}
   labels:
     app: {{ .Values.name }}

--- a/helm/kubernetes-nginx-ingress-controller-chart/charts/migration/templates/configmap.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/charts/migration/templates/configmap.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     "helm.sh/hook": "pre-install"
     "helm.sh/hook-weight": "-2"
-    "helm.sh/hook-delete-policy": "hook-succeeded"
+    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
   labels:
     app: {{ .Values.name }}
     giantswarm.io/service-type: "managed"

--- a/helm/kubernetes-nginx-ingress-controller-chart/charts/migration/templates/rbac.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/charts/migration/templates/rbac.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     "helm.sh/hook": "pre-install"
     "helm.sh/hook-weight": "-1"
-    "helm.sh/hook-delete-policy": "hook-succeeded"
+    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
   labels:
     app: {{ .Values.name }}
     giantswarm.io/service-type: "managed"

--- a/helm/kubernetes-nginx-ingress-controller-chart/charts/migration/templates/service-account.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/charts/migration/templates/service-account.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     "helm.sh/hook": "pre-install"
     "helm.sh/hook-weight": "-1"
-    "helm.sh/hook-delete-policy": "hook-succeeded"
+    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
   namespace: {{ .Values.namespace }}
   labels:
     app: {{ .Values.name }}

--- a/helm/kubernetes-nginx-ingress-controller-chart/charts/tempresources/templates/configmap.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/charts/tempresources/templates/configmap.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     "helm.sh/hook": "pre-install"
     "helm.sh/hook-weight": "-12"
-    "helm.sh/hook-delete-policy": "hook-succeeded"
+    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
   labels:
     app: {{ .Values.name }}
     giantswarm.io/service-type: "managed"

--- a/helm/kubernetes-nginx-ingress-controller-chart/charts/tempresources/templates/rbac.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/charts/tempresources/templates/rbac.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     "helm.sh/hook": "pre-install"
     "helm.sh/hook-weight": "-11"
-    "helm.sh/hook-delete-policy": "hook-succeeded"
+    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
   labels:
     app: {{ .Values.name }}
     giantswarm.io/service-type: "managed"

--- a/helm/kubernetes-nginx-ingress-controller-chart/charts/tempresources/templates/service-account.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/charts/tempresources/templates/service-account.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     "helm.sh/hook": "pre-install"
     "helm.sh/hook-weight": "-11"
-    "helm.sh/hook-delete-policy": "hook-succeeded"
+    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
   namespace: {{ .Values.namespace }}
   labels:
     app: {{ .Values.name }}


### PR DESCRIPTION
Fixes a problem with the CoreDNS migration. First time chart-operator fails to install CoreDNS. The 2nd time CoreDNS succeeds but Ingress Controller fails because of leftovers from the 1st failed run.

Fix is to delete non job resources if the hook fails. This also makes the migration jobs more robust.