### PR TITLE
Update nginx-ingress-controller to 0.21.0

### DIFF
--- a/helm/kubernetes-nginx-ingress-controller-chart/Chart.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: v0.21.0
 description: A Helm chart for the nginx ingress-controller
 name: kubernetes-nginx-ingress-controller-chart
-version: 0.3.4-[[ .SHA ]]
+version: 0.4.0-[[ .SHA ]]

--- a/helm/kubernetes-nginx-ingress-controller-chart/Chart.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: v0.15.0
+appVersion: v0.21.0
 description: A Helm chart for the nginx ingress-controller
 name: kubernetes-nginx-ingress-controller-chart
 version: 0.3.4-[[ .SHA ]]

--- a/helm/kubernetes-nginx-ingress-controller-chart/values.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/values.yaml
@@ -34,7 +34,7 @@ controller:
 
   image:
     repository: giantswarm/nginx-ingress-controller
-    tag: 0.15.0
+    tag: 0.21.0
 
   rbac:
     privilegedPod:


### PR DESCRIPTION
Update nginx-ingress-controller to `0.21.0`.

This serves two purpose at once:
- introduce [CVE fixes](https://github.com/kubernetes/ingress-nginx/releases/tag/nginx-0.21.0) 
- fixes an [issue](https://github.com/giantswarm/giantswarm/issues/4609) encountered by a customer which was fixed in `0.17.0`

Note: merge after https://github.com/giantswarm/retagger/pull/157