### PR TITLE
Add safe evict annotation in default http backend too

### DIFF
--- a/helm/kubernetes-nginx-ingress-controller-chart/templates/default-backend-deployment.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/templates/default-backend-deployment.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         releasetime: {{ $.Release.Time }}
+        cluster-autoscaler.kubernetes.io/safe-to-evict: 'true'
       labels:
         app: {{ .Values.defaultBackend.name }}
         giantswarm.io/service-type: "managed"


### PR DESCRIPTION
We have set the annotation `cluster-autoscaler.kubernetes.io/safe-to-evict: 'true'` for nginx deployment but not for the default backend. A customer noticed it is blocking scaling down a node.