### PR TITLE
Let configure the nginx classname via user values

### DIFF
--- a/helm/kubernetes-nginx-ingress-controller-chart/Chart.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: v0.21.0
 description: A Helm chart for the nginx ingress-controller
 name: kubernetes-nginx-ingress-controller-chart
-version: 0.4.3-[[ .SHA ]]
+version: 0.4.4-[[ .SHA ]]

--- a/helm/kubernetes-nginx-ingress-controller-chart/templates/controller-deployment.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/templates/controller-deployment.yaml
@@ -64,7 +64,10 @@ spec:
         - /nginx-ingress-controller
         - --default-backend-service=$(POD_NAMESPACE)/{{ .Values.defaultBackend.name }}
         - --configmap=$(POD_NAMESPACE)/{{ .Values.controller.configmap.name }}
-        - --annotations-prefix={{ index .Values.configmap "classname" }}
+        - --annotations-prefix={{ index .Values.configmap "annotations-prefix" }}
+        {{- if index .Values.configmap "default-ssl-certificate" }}
+        - --default-ssl-certificate={{ index .Values.configmap "default-ssl-certificate" }}
+        {{- end}}
         - --enable-ssl-chain-completion=false
         env:
         - name: POD_NAME

--- a/helm/kubernetes-nginx-ingress-controller-chart/templates/controller-deployment.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/templates/controller-deployment.yaml
@@ -64,7 +64,7 @@ spec:
         - /nginx-ingress-controller
         - --default-backend-service=$(POD_NAMESPACE)/{{ .Values.defaultBackend.name }}
         - --configmap=$(POD_NAMESPACE)/{{ .Values.controller.configmap.name }}
-        - --annotations-prefix=nginx.ingress.kubernetes.io
+        - --annotations-prefix={{ index .Values.configmap "classname" }}
         - --enable-ssl-chain-completion=false
         env:
         - name: POD_NAME

--- a/helm/kubernetes-nginx-ingress-controller-chart/values.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/values.yaml
@@ -25,7 +25,8 @@ configmap:
   vts-default-filter-key: ""
 
   # command args options
-  classname: nginx.ingress.kubernetes.io
+  annotations-prefix: nginx.ingress.kubernetes.io
+  default-ssl-certificate: ""
 
 controller:
   name: nginx-ingress-controller

--- a/helm/kubernetes-nginx-ingress-controller-chart/values.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/values.yaml
@@ -24,6 +24,9 @@ configmap:
   use-proxy-protocol: ""
   vts-default-filter-key: ""
 
+  # command args options
+  classname: nginx.ingress.kubernetes.io
+
 controller:
   name: nginx-ingress-controller
   k8sAppLabel: nginx-ingress-controller


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/5483

Make `default-ssl-certificate` and `annotations-prefix` configurable through the config map user values