### PR TITLE
Bump to 0.23.0 

### DIFF
--- a/helm/kubernetes-nginx-ingress-controller-chart/Chart.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: v0.21.0
+appVersion: v0.23.0
 description: A Helm chart for the nginx ingress-controller
 name: kubernetes-nginx-ingress-controller-chart
 version: 0.5.0-[[ .SHA ]]


### PR DESCRIPTION
The version should be updated as 0.23.0
Current:
```
helm --kube-context giantswarm-acaf3 --tiller-namespace=giantswarm list
NAME                    	REVISION	UPDATED                 	STATUS  	CHART                                                       	APP VERSION	NAMESPACE

nginx-ingress-controller	2       	Thu Mar 21 16:45:07 2019	DEPLOYED	kubernetes-nginx-ingress-controller-chart-0.5.0-52ac0ab8f...	v0.21.0    	kube-system

```