### PR TITLE
Bump minor version to 23 as well in integration test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,17 +101,12 @@ workflows:
           requires:
           - build
 
-      - e2eTestMigration:
-          requires:
-          - build
-
       - deploy:
           filters:
             branches:
               only: master
           requires:
           - e2eTestBasic
-          - e2eTestMigration
 
       - publish_to_stable:
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,18 @@ jobs:
         paths:
         - ./architect
 
+  e2eTestBasic:
+    environment:
+      TEST_DIR: "integration/test/basic"
+      TEST_NAME: "basic"
+    <<: *e2eTest
+
+  e2eTestMigration:
+    environment:
+      TEST_DIR: "integration/test/migration"
+      TEST_NAME: "migration"
+    <<: *e2eTest
+
   deploy:
     machine: true
     steps:
@@ -84,6 +96,14 @@ workflows:
   build_e2e:
     jobs:
       - build
+
+      - e2eTestBasic:
+          requires:
+          - build
+
+      - e2eTestMigration:
+          requires:
+          - build
 
       - deploy:
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,6 +109,9 @@ workflows:
           filters:
             branches:
               only: master
+          requires:
+          - e2eTestBasic
+          - e2eTestMigration
 
       - publish_to_stable:
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,12 +61,6 @@ jobs:
       TEST_NAME: "basic"
     <<: *e2eTest
 
-  e2eTestMigration:
-    environment:
-      TEST_DIR: "integration/test/migration"
-      TEST_NAME: "migration"
-    <<: *e2eTest
-
   deploy:
     machine: true
     steps:

--- a/integration/templates/ingress_controller_basic_values.go
+++ b/integration/templates/ingress_controller_basic_values.go
@@ -10,7 +10,7 @@ controller:
   k8sAppLabel: nginx-ingress-controller
   metricsPort: 10254
 
-  replicas: 3
+  replicas: 1
 
   configmap:
     name: ingress-nginx

--- a/integration/templates/ingress_controller_basic_values.go
+++ b/integration/templates/ingress_controller_basic_values.go
@@ -10,7 +10,7 @@ controller:
   k8sAppLabel: nginx-ingress-controller
   metricsPort: 10254
 
-  replicas: 1
+  replicas: 3
 
   configmap:
     name: ingress-nginx

--- a/integration/templates/ingress_controller_basic_values.go
+++ b/integration/templates/ingress_controller_basic_values.go
@@ -17,7 +17,7 @@ controller:
 
   image:
     repository: giantswarm/nginx-ingress-controller
-    tag: 0.12.0
+    tag: 0.23.0
 
   service:
     enabled: true

--- a/integration/templates/ingress_controller_migration_values.go
+++ b/integration/templates/ingress_controller_migration_values.go
@@ -17,7 +17,7 @@ controller:
 
   image:
     repository: giantswarm/nginx-ingress-controller
-    tag: 0.12.0
+    tag: 0.23.0
 
   service:
     enabled: false

--- a/integration/test/basic/main_test.go
+++ b/integration/test/basic/main_test.go
@@ -121,7 +121,7 @@ func init() {
 							"giantswarm.io/service-type": "managed",
 							"k8s-app":                    controllerName,
 						},
-						Replicas: 1,
+						Replicas: 3,
 					},
 					{
 						Name:      defaultBackendName,

--- a/integration/test/basic/main_test.go
+++ b/integration/test/basic/main_test.go
@@ -121,7 +121,7 @@ func init() {
 							"giantswarm.io/service-type": "managed",
 							"k8s-app":                    controllerName,
 						},
-						Replicas: 3,
+						Replicas: 1,
 					},
 					{
 						Name:      defaultBackendName,


### PR DESCRIPTION
During nginx `0.23.0` installation, it could not find the specific parameter. 
```
unknown flag: --enable-dynamic-certificates
Usage of :
      --alsologtostderr                   log to standard error as well as files
      --annotations-prefix string         Prefix of the ingress annotations. (default "nginx.ingress.kubernetes.io")
      --apiserver-host string             The add
```
So we should change the same version in our test.