### PR TITLE
Allow all egress traffic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project's packages adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.8.1]
+
+### Changed
+
+- Allow all egress traffic via network policy.
+
+
 ## [0.8.0]
 
 ### Added

--- a/helm/kubernetes-nginx-ingress-controller-chart/Chart.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: v0.24.1
 description: A Helm chart for the nginx ingress-controller
 name: kubernetes-nginx-ingress-controller-chart
-version: 0.8.0-[[ .SHA ]]
+version: 0.8.1-[[ .SHA ]]

--- a/helm/kubernetes-nginx-ingress-controller-chart/templates/np.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/templates/np.yaml
@@ -20,13 +20,7 @@ spec:
     - port: {{ .Values.controller.metricsPort }}
       protocol: TCP
   egress:
-  - to:
-    - ipBlock:
-        cidr: 10.0.0.0/8
-    - ipBlock:
-        cidr: 172.16.0.0/12
-    - ipBlock:
-        cidr: 192.168.0.0/16
+  - {}
   policyTypes:
   - Egress
   - Ingress


### PR DESCRIPTION
Required to fix broken ingresses, configured auth-redirects.
```
nginx.ingress.kubernetes.io/auth-url: "https://$host/oauth2/auth"
nginx.ingress.kubernetes.io/auth-signin: "https://$host/oauth2/start?rd=$request_uri"
```