### PR TITLE
Update values structure for HPA settings

### DIFF
--- a/helm/kubernetes-nginx-ingress-controller-chart/templates/controller-hpa.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/templates/controller-hpa.yaml
@@ -1,4 +1,4 @@
-{{- if index .Values.configmap.hpa-enabled }}
+{{- if (index .Values.configmap.hpa-enabled) eq "true" }}
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:

--- a/helm/kubernetes-nginx-ingress-controller-chart/templates/controller-hpa.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/templates/controller-hpa.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.configmap.autoscaling.enabled }}
+{{- if .Values.configmap.hpa-enabled }}
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
@@ -13,15 +13,15 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: {{ .Values.controller.name }}
-  minReplicas: {{ index .Values.configmap.autoscaling "min-replicas" }}
-  maxReplicas: {{ index .Values.configmap.autoscaling "max-replicas" }}
+  minReplicas: {{ .Values.configmap.hpa-min-replicas" }}
+  maxReplicas: {{ .Values.configmap.hpa-max-replicas" }}
   metrics:
     - type: Resource
       resource:
         name: cpu
-        targetAverageUtilization: {{ index .Values.configmap.autoscaling "target-cpu-utilization-percentage" }}
+        targetAverageUtilization: {{ .Values.configmap.hpa-target-cpu-utilization-percentage" }}
     - type: Resource
       resource:
         name: memory
-        targetAverageUtilization: {{ index .Values.configmap.autoscaling "target-memory-utilization-percentage" }}
+        targetAverageUtilization: {{ .Values.configmap.hpa-target-memory-utilization-percentage" }}
 {{- end }}

--- a/helm/kubernetes-nginx-ingress-controller-chart/templates/controller-hpa.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/templates/controller-hpa.yaml
@@ -1,4 +1,4 @@
-{{- if (index .Values.configmap.hpa-enabled) eq "true" }}
+{{- if (index .Values.configmap "hpa-enabled") eq "true" }}
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
@@ -13,15 +13,15 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: {{ .Values.controller.name }}
-  minReplicas: {{ index .Values.configmap.hpa-min-replicas" }}
-  maxReplicas: {{ index .Values.configmap.hpa-max-replicas" }}
+  minReplicas: {{ index .Values.configmap "hpa-min-replicas" }}
+  maxReplicas: {{ index .Values.configmap "hpa-max-replicas" }}
   metrics:
     - type: Resource
       resource:
         name: cpu
-        targetAverageUtilization: {{ index .Values.configmap.hpa-target-cpu-utilization-percentage" }}
+        targetAverageUtilization: {{ index .Values.configmap "hpa-target-cpu-utilization-percentage" }}
     - type: Resource
       resource:
         name: memory
-        targetAverageUtilization: {{ index .Values.configmap.hpa-target-memory-utilization-percentage" }}
+        targetAverageUtilization: {{ index .Values.configmap "hpa-target-memory-utilization-percentage" }}
 {{- end }}

--- a/helm/kubernetes-nginx-ingress-controller-chart/templates/controller-hpa.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/templates/controller-hpa.yaml
@@ -13,15 +13,15 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: {{ .Values.controller.name }}
-  minReplicas: {{ .Values.configmap.hpa-min-replicas" }}
-  maxReplicas: {{ .Values.configmap.hpa-max-replicas" }}
+  minReplicas: {{ index .Values.configmap.hpa-min-replicas" }}
+  maxReplicas: {{ index .Values.configmap.hpa-max-replicas" }}
   metrics:
     - type: Resource
       resource:
         name: cpu
-        targetAverageUtilization: {{ .Values.configmap.hpa-target-cpu-utilization-percentage" }}
+        targetAverageUtilization: {{ index .Values.configmap.hpa-target-cpu-utilization-percentage" }}
     - type: Resource
       resource:
         name: memory
-        targetAverageUtilization: {{ .Values.configmap.hpa-target-memory-utilization-percentage" }}
+        targetAverageUtilization: {{ index .Values.configmap.hpa-target-memory-utilization-percentage" }}
 {{- end }}

--- a/helm/kubernetes-nginx-ingress-controller-chart/templates/controller-hpa.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/templates/controller-hpa.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.configmap.hpa-enabled }}
+{{- if index .Values.configmap.hpa-enabled }}
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:

--- a/helm/kubernetes-nginx-ingress-controller-chart/values.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/values.yaml
@@ -17,13 +17,6 @@ configmap:
   worker-processes: "4"
   use-forwarded-headers: "true"
 
-  autoscaling:
-    enabled: false
-    min-replicas: 2
-    max-replicas: 15
-    target-cpu-utilization-percentage: 50
-    target-memory-utilization-percentage: 50
-
   # optional settings that can be set.
   enable-underscores-in-headers: ""
   large-client-header-buffers: ""
@@ -32,6 +25,13 @@ configmap:
   proxy-buffers: ""
   use-proxy-protocol: ""
   vts-default-filter-key: ""
+  
+  # optional hpa settings
+  hpa-enabled: false
+  hpa-min-replicas: 2
+  hpa-max-replicas: 15
+  hpa-target-cpu-utilization-percentage: 50
+  hpa-memory-utilization-percentage: 50
 
   # command args options
   annotations-prefix: nginx.ingress.kubernetes.io

--- a/helm/kubernetes-nginx-ingress-controller-chart/values.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/values.yaml
@@ -31,7 +31,7 @@ configmap:
   hpa-min-replicas: 2
   hpa-max-replicas: 15
   hpa-target-cpu-utilization-percentage: 50
-  hpa-memory-utilization-percentage: 50
+  hpa-target-memory-utilization-percentage: 50
 
   # command args options
   annotations-prefix: nginx.ingress.kubernetes.io


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/5264

For chartconfig CRs we only allow values to be set under `.configmap` and we can't support nested keys. So this renames the keys to have a `hpa-` prefix.