### PR TITLE
Reduce hpa replicas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project's packages adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.10.0]
+
+### Changed
+
+- Reduce max replicas for HPA from 15 to 11 based on a recommendation from upstream.
+
 ## [0.9.1]
 
 - Fix a security issue on nginx-ingress by using the latest version [0.25.1](https://github.com/kubernetes/ingress-nginx/releases/tag/nginx-0.25.1). 

--- a/helm/kubernetes-nginx-ingress-controller-chart/Chart.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: v0.25.1
 description: A Helm chart for the nginx ingress-controller
 name: kubernetes-nginx-ingress-controller-chart
-version: 0.9.1-[[ .SHA ]]
+version: 0.10.0-[[ .SHA ]]

--- a/helm/kubernetes-nginx-ingress-controller-chart/values.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/values.yaml
@@ -29,7 +29,7 @@ configmap:
   # optional hpa settings
   hpa-enabled: false
   hpa-min-replicas: 2
-  hpa-max-replicas: 15
+  hpa-max-replicas: 11
   hpa-target-cpu-utilization-percentage: 50
   hpa-target-memory-utilization-percentage: 50
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/5264

Reduces the HPA max replicas from 15 to 11 which is a recommendation from upstream. As running more than 10-12 replicas does not make sense.