### PR TITLE
Use kind cluster with 3 workers in e2e

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ e2eTest: &e2eTest
     - run:
         name: Init cluster
         command: |
-          ./e2ectl cluster create
+          ./e2ectl cluster create --worker-count=3
           cp $(./e2ectl kubeconfig path) ${E2E_TEST_DIR}/kubeconfig
 
     - run:

--- a/integration/templates/ingress_controller_basic_values.go
+++ b/integration/templates/ingress_controller_basic_values.go
@@ -10,7 +10,7 @@ controller:
   k8sAppLabel: nginx-ingress-controller
   metricsPort: 10254
 
-  replicas: 1
+  replicas: 3
   maxUnavailable: 0
 
   configmap:

--- a/integration/test/basic/main_test.go
+++ b/integration/test/basic/main_test.go
@@ -133,7 +133,7 @@ func init() {
 							"giantswarm.io/service-type": "managed",
 							"k8s-app":                    controllerName,
 						},
-						Replicas: 1,
+						Replicas: 3,
 					},
 				},
 			},


### PR DESCRIPTION
When we added the pod anti-affinities we had to reduce the replicas from 3 to 1.

This puts it back and we now run 1 master and 3 worker nodes. The Circle VMs have 8GB RAM so running this size of cluster is fine. This also lets us run deeper e2e tests for IC in future.

Thanks @sslavic for doing the heavy lifting here to make this possible. ❤️ 
