### PR TITLE
Revert multi node cluster changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ e2eTest: &e2eTest
     - run:
         name: Init cluster
         command: |
-          ./e2ectl cluster create --worker-count=3
+          ./e2ectl cluster create
           cp $(./e2ectl kubeconfig path) ${E2E_TEST_DIR}/kubeconfig
 
     - run:

--- a/integration/templates/ingress_controller_basic_values.go
+++ b/integration/templates/ingress_controller_basic_values.go
@@ -10,7 +10,7 @@ controller:
   k8sAppLabel: nginx-ingress-controller
   metricsPort: 10254
 
-  replicas: 3
+  replicas: 1
   maxUnavailable: 0
 
   configmap:

--- a/integration/test/basic/main_test.go
+++ b/integration/test/basic/main_test.go
@@ -133,7 +133,7 @@ func init() {
 							"giantswarm.io/service-type": "managed",
 							"k8s-app":                    controllerName,
 						},
-						Replicas: 3,
+						Replicas: 1,
 					},
 				},
 			},


### PR DESCRIPTION
Due to the upgrade to kind 0.5.1 creating multiple workers doesn't work. Now you have to create a kind config file.

https://github.com/giantswarm/e2ectl/pull/23

Reverting until I can add e2ectl support.


