### PR TITLE
Add option to add http snippet to the configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project's packages adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.1]
+
+### Changed
+
+- Add optional status endpoint in port `18080` to enable instana to scrape nginx stats.
+
 ## [1.0.0]
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Changed
 
-- Add optional status endpoint in port `18080` to enable instana to scrape nginx stats.
+- Add optional http snippet parameter to extend nginx http configuration.
 
 ## [1.0.0]
 

--- a/helm/kubernetes-nginx-ingress-controller-chart/Chart.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: v0.26.1
 description: A Helm chart for the nginx ingress-controller
 name: kubernetes-nginx-ingress-controller-chart
-version: 1.0.0-[[ .SHA ]]
+version: 1.0.1-[[ .SHA ]]

--- a/helm/kubernetes-nginx-ingress-controller-chart/templates/configmap.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/templates/configmap.yaml
@@ -6,20 +6,6 @@ metadata:
   labels:
     giantswarm.io/service-type: "managed"
     k8s-addon: ingress-nginx.addons.k8s.io
-    {{- if .Values.configmap.status_ep_enabled }}
-    http-snippet: |
-      server {
-        listen 18080;
-
-        location /nginx_status {
-          stub_status on;
-        }
-
-        location / {
-          return 404;
-        }
-      }
-    {{- end }}
 data:
 
   disable-access-log: "{{ index .Values.configmap "disable-access-log" }}"
@@ -31,6 +17,13 @@ data:
   # Disables setting a 'Strict-Transport-Security' header, which can be harmful.
   # See https://github.com/kubernetes/ingress-nginx/issues/549#issuecomment-291894246
   hsts: "{{ .Values.configmap.hsts }}"
+
+  {{- if index .Values.configmap "http-snippet" }}
+  http-snippet: |
+  {{- range (.Values.configmap.http-snippet | trimAll "\n " |  split "\n") }}
+    {{ . }}
+  {{- end }}
+  {{- end }}
 
   {{- if index .Values.configmap "large-client-header-buffers" }}
   large-client-header-buffers: "{{ index .Values.configmap "large-client-header-buffers" }}"

--- a/helm/kubernetes-nginx-ingress-controller-chart/templates/configmap.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/templates/configmap.yaml
@@ -6,12 +6,26 @@ metadata:
   labels:
     giantswarm.io/service-type: "managed"
     k8s-addon: ingress-nginx.addons.k8s.io
+    {{- if .Values.configmap.status_ep_enabled }}
+    http-snippet: |
+      server {
+        listen 18080;
+
+        location /nginx_status {
+          stub_status on;
+        }
+
+        location / {
+          return 404;
+        }
+      }
+    {{- end }}
 data:
 
   disable-access-log: "{{ index .Values.configmap "disable-access-log" }}"
   {{- if index .Values.configmap "enable-underscores-in-headers" }}
   enable-underscores-in-headers: "{{ index .Values.configmap "enable-underscores-in-headers" }}"
-  {{- end}}
+  {{- end }}
   enable-vts-status: "{{ index .Values.configmap "enable-vts-status" }}"
   error-log-level: "{{ index .Values.configmap "error-log-level" }}"
   # Disables setting a 'Strict-Transport-Security' header, which can be harmful.

--- a/helm/kubernetes-nginx-ingress-controller-chart/templates/configmap.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/templates/configmap.yaml
@@ -20,7 +20,7 @@ data:
 
   {{- if index .Values.configmap "http-snippet" }}
   http-snippet: |
-  {{- range (.Values.configmap.http-snippet | trimAll "\n " |  split "\n") }}
+  {{- range ((index .Values.configmap "http-snippet") | trimAll "\n " |  split "\n") }}
     {{ . }}
   {{- end }}
   {{- end }}

--- a/helm/kubernetes-nginx-ingress-controller-chart/values.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/values.yaml
@@ -37,6 +37,9 @@ configmap:
   annotations-prefix: nginx.ingress.kubernetes.io
   default-ssl-certificate: ""
 
+  # enable status endpoint for instance
+  status_ep_enabled: false
+
 controller:
   name: nginx-ingress-controller
   k8sAppLabel: nginx-ingress-controller

--- a/helm/kubernetes-nginx-ingress-controller-chart/values.yaml
+++ b/helm/kubernetes-nginx-ingress-controller-chart/values.yaml
@@ -19,6 +19,7 @@ configmap:
 
   # optional settings that can be set.
   enable-underscores-in-headers: ""
+  http-snippet: ""
   large-client-header-buffers: ""
   log-format-upstream: ""
   proxy-buffers-size: ""
@@ -36,9 +37,6 @@ configmap:
   # command args options
   annotations-prefix: nginx.ingress.kubernetes.io
   default-ssl-certificate: ""
-
-  # enable status endpoint for instance
-  status_ep_enabled: false
 
 controller:
   name: nginx-ingress-controller


### PR DESCRIPTION
Some tools need to extend http configuration of the nginx

For example: https://docs.instana.io/ecosystem/nginx/#kubernetes-nginx-ingress